### PR TITLE
Fix QA refs and deduplicate W&B Report sections

### DIFF
--- a/INDEX_RULES.md
+++ b/INDEX_RULES.md
@@ -9,7 +9,7 @@ Load only the docs relevant to your current task.
 1. **Never commit secrets.** Use environment variables or reference existing config files (`~/keys/`, `~/.ssh/config`).
 2. **Prefer references over full context loading.** Cite file paths as text (e.g., `~/agents-config/machine/mac.md`); load the file only when the task needs it. A "reference" here is a written path to a doc — not a symlink or memory address.
 3. **Verify before pushing.** Review diffs for secrets, unintended changes, broken imports.
-4. **Before sending your final response on any non-trivial user request, dispatch a cross-agent reviewer.** One QA pass per user-assigned task, not per commit. See [`workflows/qa-gating.md`](workflows/qa-gating.md).
+4. **Before sending your final response on any non-trivial user request, run the two-step QA chain.** One QA chain per user-assigned task, not per commit. Step 1: correctness ([`workflows/qa-correctness.md`](workflows/qa-correctness.md)). Step 2: structural ([`workflows/qa-structural.md`](workflows/qa-structural.md)) — skipped for markdown-only repos.
 5. **Keep `agents-config` self-consistent.** When modifying this repo, ensure INDEX_RULES.md, README.md, and listed doc paths remain accurate.
 6. **Use explicit anchored paths in prose doc references and commands.** Write `~/agents-config/INDEX_RULES.md` or `~/veribench/docs/agent-docs/INDEX.md`, never bare relative references like `docs/agent-docs/`. The user works across many repos and machines, so unanchored paths are ambiguous without context.
 7. **Re-read agent-config files after any edit.** If you or the user modify any file under `~/agents-config/` (for example `~/agents-config/INDEX_RULES.md`, `~/agents-config/README.md`, files under `~/agents-config/workflows/`, or files under `~/agents-config/machine/`), immediately re-read the changed file(s) so your context stays current for the rest of the conversation.
@@ -33,7 +33,8 @@ Load the one matching your current environment. Machine docs contain only behavi
 
 ## Workflows
 
-- [`workflows/qa-gating.md`](workflows/qa-gating.md) — cross-agent review protocol (default-on)
+- [`workflows/qa-correctness.md`](workflows/qa-correctness.md) — cross-agent correctness review (step 1, default-on)
+- [`workflows/qa-structural.md`](workflows/qa-structural.md) — anti-degradation refactoring gate (step 2, skipped for markdown-only repos)
 - [`workflows/git-worktrees.md`](workflows/git-worktrees.md) — worktree isolation for parallel agents
 - [`workflows/expts-and-results.md`](workflows/expts-and-results.md) — experiment structure and results reporting
 - [`workflows/tweprints.md`](workflows/tweprints.md) — tweet thread format for research announcements

--- a/workflows/expts-and-results.md
+++ b/workflows/expts-and-results.md
@@ -49,68 +49,21 @@ experiments/<NN>_<name>/
 - **Entity:** `brando-su`
 - **Project:** depends on experiment (e.g., `vb-thm-eq` for judge correlation, `veribench-e3-agents` for agent benchmarks).
 - **API key:** `export WANDB_API_KEY=$(cat ~/keys/brandos_wandb_key.txt)`
+- **Dependency:** `pip install wandb[workspaces]` (required for Reports API).
 - Log all key metrics, plots, and config as artifacts.
-- **Generate a W&B Report** after logging is complete — not just runs/artifacts. A Report is a shareable dashboard with a permanent URL. Use the W&B Reports API: https://docs.wandb.ai/models/reports
-- **Include the Report URL** in the results summary file and in the final response to the user. This is the primary deliverable — the user needs a clickable link to the Report, not just confirmation that metrics were logged.
-- **Dependency:** Reports require `pip install wandb[workspaces]` (not just `wandb`). Ensure this is installed before calling the Reports API.
-- **Reference test:** See `~/agent-config/tests/dummy_experiment/train.py` for a working example of training + W&B logging + Report creation.
 
-### Local Experiment Reports
+### W&B Reports (mandatory)
 
-In addition to W&B, **always save a local markdown report** in the experiment's `results_summary/` folder. This is the offline-readable copy of what the W&B Report shows.
+Every experiment must produce a W&B Report — a shareable interactive document with a permanent URL. A logged run alone is NOT sufficient. Ref: https://docs.wandb.ai/models/reports
 
-The local report must include:
-- **TL;DR** — 1-3 sentence summary of results at the top
-- **Config table** — all hyperparameters
-- **Results table** — final metrics
-- **Plots** — saved as PNGs in `results_summary/plots/`, referenced via relative paths in the markdown (e.g., `![Loss](plots/loss_<timestamp>.png)`)
-- **W&B link** — Report URL if available, otherwise "N/A (offline or no API key)"
+After any experiment completes:
 
-File naming: `results_summary/results_summary_<YYYY-MM-DD__HH-MM-SS>.md` (same timestamping convention as the rest of this workflow).
+1. **Push metrics** via `push_to_wandb.py` or inline `wandb.log()`.
+2. **Create a Report** with: title (`<Experiment> — <Date>`), TL;DR, metric plots, config details, leaderboard table (if comparing models).
+3. **Print the Report URL** — this is the primary deliverable.
+4. **Include the Report URL** in the results summary file and in the final response to the user.
 
-Markdown with relative-path PNGs works in GitHub, VS Code, and most editors — no localhost server needed.
-
----
-
-## Post-Experiment GPU Cleanup
-
-After any training, eval, or QA run completes, check that no GPU processes are left behind. Handle this autonomously — only escalate to the user if there is a critical ambiguity.
-
-1. **Confirm the experiment is actually finished:**
-   - The process exited (exit code 0 or non-zero)
-   - W&B sync/push completed (if applicable)
-   - No checkpoint save or model upload is still in progress
-   - No other experiment or pipeline stage depends on the process
-2. **Check for lingering GPU processes:**
-   ```bash
-   nvidia-smi --query-compute-apps=pid,process_name,used_memory --format=csv,noheader
-   ```
-3. **If all checks pass**, kill lingering processes owned by the user without asking:
-   ```bash
-   kill <pid>
-   ```
-4. **Only ask the user if there is a critical ambiguity** — e.g., the process is shared across experiments, a multi-stage pipeline has unclear state, or the exit status is unclear. This follows the same escalation rule as QA gating: autonomous unless critical.
-
-### MANDATORY: Always create a W&B Report after every experiment run
-
-A W&B **Report** (https://docs.wandb.ai/models/reports) is a shareable interactive document — NOT just a logged run. Every experiment MUST produce one.
-
-After completing any experiment (benchmark run, proof pass, agent evaluation, etc.):
-
-1. **Push metrics to W&B** via the experiment's `push_to_wandb.py` or inline `wandb.log()`.
-2. **Create a W&B Report** (the actual Report document, via `wandb.apis.reports` or the API):
-   - **Title:** `<Experiment Name> — <Date>` (e.g., `VeriBench E3 Results — 2026-04-03`)
-   - **TL;DR:** 1-2 sentence key finding at the top
-   - **Leaderboard table** (if comparing agents/models)
-   - **Metric plots** (bar charts, scatter, etc.) embedded from the run
-   - **Config details:** exact model IDs, hyperparameters, dataset version
-   - **Appendix:** verification checklist confirming results are correct
-3. **Log as W&B artifact** if producing CSVs, JSONs, or plot images.
-4. **Print the Report URL** so it can be shared with the team.
-
-**How to create a Report programmatically:**
 ```python
-# Use wandb-workspaces (pip install wandb-workspaces), NOT the old wandb.apis.reports
 import wandb_workspaces.reports.v2 as wr
 
 report = wr.Report(
@@ -133,9 +86,43 @@ report.save()
 print(f"Report URL: {report.url}")
 ```
 
-**Ref:** https://docs.wandb.ai/models/reports
+**Reference test:** See `~/agents-config/tests/dummy_experiment/train.py` for a working example.
 
-This is non-negotiable — every experiment must have a W&B Report for tracking and reproducibility. A logged run alone is NOT sufficient.
+### Local Experiment Reports
+
+In addition to W&B, **always save a local markdown report** in the experiment's `results_summary/` folder. This is the offline-readable copy of what the W&B Report shows.
+
+The local report must include:
+- **TL;DR** — 1-3 sentence summary of results at the top
+- **Config table** — all hyperparameters
+- **Results table** — final metrics
+- **Plots** — saved as PNGs in `results_summary/plots/`, referenced via relative paths (e.g., `![Loss](plots/loss_<timestamp>.png)`)
+- **W&B link** — Report URL if available, otherwise "N/A (offline or no API key)"
+
+File naming: `results_summary/results_summary_<YYYY-MM-DD__HH-MM-SS>.md`.
+
+Markdown with relative-path PNGs works in GitHub, VS Code, and most editors — no localhost server needed.
+
+---
+
+## Post-Experiment GPU Cleanup
+
+After any training, eval, or QA run completes, check that no GPU processes are left behind. Handle this autonomously — only escalate to the user if there is a critical ambiguity.
+
+1. **Confirm the experiment is actually finished:**
+   - The process exited (exit code 0 or non-zero)
+   - W&B sync/push completed (if applicable)
+   - No checkpoint save or model upload is still in progress
+   - No other experiment or pipeline stage depends on the process
+2. **Check for lingering GPU processes:**
+   ```bash
+   nvidia-smi --query-compute-apps=pid,process_name,used_memory --format=csv,noheader
+   ```
+3. **If all checks pass**, kill lingering processes owned by the user without asking:
+   ```bash
+   kill <pid>
+   ```
+4. **Only ask the user if there is a critical ambiguity** — e.g., the process is shared across experiments, a multi-stage pipeline has unclear state, or the exit status is unclear. Same escalation rule as QA: autonomous unless critical.
 
 ---
 


### PR DESCRIPTION
## Summary

- Fix rule 4 in INDEX_RULES.md: now references both `qa-correctness.md` and `qa-structural.md` (the old `qa-gating.md` was renamed/split)
- Fix workflows listing: shows both QA docs instead of the deleted `qa-gating.md`
- Deduplicate W&B Report sections in `expts-and-results.md` — two overlapping sections merged into one clean one
- Fix stale path `~/agent-config/` → `~/agents-config/`
- Net -12 lines (55 deleted, 43 added)

## Test plan

- [x] Verified `qa-gating.md` no longer exists, `qa-correctness.md` and `qa-structural.md` do
- [x] No broken internal links

https://claude.ai/code/session_0138D43YvNfCWY5oTBCG8LJP