### PR TITLE
Add remote fallback rule for cloud/phone environments

### DIFF
--- a/INDEX_RULES.md
+++ b/INDEX_RULES.md
@@ -2,6 +2,8 @@
 
 Load only the docs relevant to your current task.
 
+**Remote fallback:** If `~/agents-config/` is not available locally (e.g., running in a cloud sandbox or on the phone), fetch any needed files from `https://raw.githubusercontent.com/brando90/agents-config/main/`. This applies to this file, all machine docs, all workflow docs, and anything else referenced below.
+
 ---
 
 ## Global Rules (always active)


### PR DESCRIPTION
## Summary

- Added a remote fallback preamble to INDEX_RULES.md: if `~/agents-config/` isn't available locally (cloud sandbox, phone), fetch any needed files from `https://raw.githubusercontent.com/brando90/agents-config/main/`
- Covers all docs — machine configs, workflows, everything
- No changes needed in project repos' CLAUDE.md files
- No submodules, no inlining, always up to date

## Test plan

- [x] Rule is at the top of INDEX_RULES.md, visible before any doc routing
- [x] URL points to correct repo and branch

https://claude.ai/code/session_0138D43YvNfCWY5oTBCG8LJP