### PR TITLE
Restructure rules into Hard/Trigger/Guidelines tiers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,10 @@
 # Claude Code: read `~/agents-config/INDEX_RULES.md` for all agent documentation and routing.
+
+## Mandatory Response Protocol (inline — do not skip)
+
+These are duplicated here from INDEX_RULES.md Hard Rules so you see them at session start without needing to dereference. They apply to EVERY response in EVERY session.
+
+1. **TLDR** — End every response with `**TLDR:**` (1-2 sentences). No exceptions.
+2. **QA gating** — Before reporting a non-trivial task as "done," run the two-step QA chain (Hard Rule 3 in `~/agents-config/INDEX_RULES.md`). When unsure whether to run it, run it.
+3. **No secrets** — Never commit secrets. Review diffs before pushing.
+4. **Fresh config** — At the start of each new task, `git -C ~/agents-config pull` and re-read `~/agents-config/INDEX_RULES.md`.

--- a/INDEX_RULES.md
+++ b/INDEX_RULES.md
@@ -6,21 +6,36 @@ Load only the docs relevant to your current task.
 
 ---
 
-## Global Rules (always active)
+## Hard Rules (every response, never skip)
+
+These rules apply to EVERY agent response and EVERY session. Violating any of these is a failure.
 
 1. **Never commit secrets.** Use environment variables or reference existing config files (`~/keys/`, `~/.ssh/config`).
-2. **Prefer references over full context loading.** Cite file paths as text (e.g., `~/agents-config/machine/mac.md`); load the file only when the task needs it. A "reference" here is a written path to a doc — not a symlink or memory address.
-3. **Verify before pushing.** Review diffs for secrets, unintended changes, broken imports.
-4. **Before sending your final response on any non-trivial user request, run the two-step QA chain sequentially.** One QA chain per user-assigned task, not per commit. Step 1: correctness ([`workflows/qa-correctness.md`](workflows/qa-correctness.md)) — must pass before step 2. Step 2: structural ([`workflows/qa-structural.md`](workflows/qa-structural.md)) — skipped for markdown-only repos. **Always dispatch QA to the opposite agent** (Claude Code → Codex, Codex → Claude Code). If unavailable, use the smartest available model of your own agent type.
-5. **Keep `agents-config` self-consistent.** When modifying this repo, ensure INDEX_RULES.md, README.md, and listed doc paths remain accurate.
-6. **Use explicit anchored paths in prose doc references and commands.** Write `~/agents-config/INDEX_RULES.md` or `~/veribench/docs/agent-docs/INDEX.md`, never bare relative references like `docs/agent-docs/`. The user works across many repos and machines, so unanchored paths are ambiguous without context.
-7. **Re-read agent-config files after any edit.** If you or the user modify any file under `~/agents-config/` (for example `~/agents-config/INDEX_RULES.md`, `~/agents-config/README.md`, files under `~/agents-config/workflows/`, or files under `~/agents-config/machine/`), immediately re-read the changed file(s) so your context stays current for the rest of the conversation.
-8. **End every response with a TLDR.** Every response — not just task completion — must end with a `**TLDR:**` line: 1–2 sentences summarizing what was done or decided. This applies to all agents (Claude Code, Codex, etc.).
-9. **Refresh agents-config before each new user task.** At the start of every non-trivial user request: (1) `git -C ~/agents-config pull` to fetch remote changes, (2) re-read `~/agents-config/INDEX_RULES.md` into your active context so the current session has the latest rules and doc references, (3) if the pull brought changes, also re-read any changed machine or workflow files relevant to your current environment. For long sessions (over 1 hour), also refresh mid-task — check with `date` and compare to your last pull. Push any uncommitted agents-config changes and run QA if changes were pulled from another agent.
-10. **Always use `ls -la` (not `ls`) when listing directories for keys, tokens, configs, or credentials.** Hidden (dot-prefixed) files are common for sensitive data — plain `ls` omits them. This applies to any directory likely to hold secrets (e.g., `~/keys/`, `~/.ssh/`, `~/.config/`).
-11. **Keep PRs short.** The PR description must start with a **Summary** section of 5–10 bullet points max (one line each). Follow with a short **Test plan** (2–3 bullets). Include links (W&B Report URLs, relevant docs). After these two sections, an optional **Appendix** may contain extended details, file lists, or context — but assume the reader stops after the summary. No walls of text.
-12. **Commit and push agents-config changes immediately.** When you edit any file in `~/agents-config/`, commit and push to the remote before continuing with the next task. Other agents on other machines pull from this repo — stale config causes drift. Also ensure that any project-level config files that reference agents-config (e.g., a project's `CLAUDE.md` pointing to `~/agents-config/INDEX_RULES.md`) stay consistent. No agentic config file should go stale.
-13. **GPU discipline: estimate → suggest → ask → verify → clean up.** Before launching GPU experiments, estimate VRAM and utilization. If the job is small (<20 GB), suggest a smaller-GPU machine. If using multiple GPUs, present the plan and ask for approval. Check utilization within 2 min of launch. After experiments, kill zombies and free GPUs. See [`workflows/expts-and-results.md`](workflows/expts-and-results.md) § GPU Allocation Rules and § Post-Experiment Cleanup.
+2. **Verify before pushing.** Review diffs for secrets, unintended changes, broken imports.
+3. **Run the two-step QA chain before reporting any non-trivial task as done.** One QA chain per user-assigned task, not per commit. Step 1: correctness ([`workflows/qa-correctness.md`](workflows/qa-correctness.md)) — must pass before step 2. Step 2: structural ([`workflows/qa-structural.md`](workflows/qa-structural.md)) — skipped for markdown-only repos. **Always dispatch QA to the opposite agent** (Claude Code → Codex, Codex → Claude Code). If unavailable, use the smartest available model of your own agent type. When unsure whether to run QA, run it.
+4. **End every response with a TLDR.** Every response — not just task completion — must end with a `**TLDR:**` line: 1–2 sentences summarizing what was done or decided. This applies to all agents (Claude Code, Codex, etc.). No exceptions.
+5. **Refresh agents-config before each new user task.** At the start of every non-trivial user request: (1) `git -C ~/agents-config pull` to fetch remote changes, (2) re-read `~/agents-config/INDEX_RULES.md` into your active context so the current session has the latest rules and doc references, (3) if the pull brought changes, also re-read any changed machine or workflow files relevant to your current environment. For long sessions (over 1 hour), also refresh mid-task — check with `date` and compare to your last pull. Push any uncommitted agents-config changes and run QA if changes were pulled from another agent.
+
+---
+
+## Trigger Rules (mandatory when triggered)
+
+These rules fire in specific contexts. When the trigger condition is met, they are mandatory.
+
+6. **Commit, push, and re-read agents-config after any edit.** _Trigger: you or the user modify any file under `~/agents-config/`._ (1) Re-read the changed file(s) so your context stays current for the rest of the conversation. (2) Commit and push to the remote before continuing with the next task — other agents on other machines pull from this repo, so stale config causes drift. Also ensure project-level config files that reference agents-config (e.g., a project's `CLAUDE.md`) stay consistent.
+7. **Keep PRs short.** _Trigger: creating a pull request._ The PR description must start with a **Summary** section of 5–10 bullet points max (one line each). Follow with a short **Test plan** (2–3 bullets). Include links (W&B Report URLs, relevant docs). After these two sections, an optional **Appendix** may contain extended details, file lists, or context — but assume the reader stops after the summary. No walls of text.
+8. **GPU discipline: estimate → suggest → ask → verify → clean up.** _Trigger: about to launch a GPU job._ Before launching GPU experiments, estimate VRAM and utilization. If the job is small (<20 GB), suggest a smaller-GPU machine. If using multiple GPUs, present the plan and ask for approval. Check utilization within 2 min of launch. After experiments, kill zombies and free GPUs. See [`workflows/expts-and-results.md`](workflows/expts-and-results.md) § GPU Allocation Rules and § Post-Experiment Cleanup.
+
+---
+
+## Guidelines (best practices)
+
+Follow these as conventions. They improve quality but are lower priority than Hard Rules and Trigger Rules.
+
+9. **Prefer references over full context loading.** Cite file paths as text (e.g., `~/agents-config/machine/mac.md`); load the file only when the task needs it. A "reference" here is a written path to a doc — not a symlink or memory address.
+10. **Keep `agents-config` self-consistent.** When modifying this repo, ensure INDEX_RULES.md, README.md, and listed doc paths remain accurate.
+11. **Use explicit anchored paths in prose doc references and commands.** Write `~/agents-config/INDEX_RULES.md` or `~/veribench/docs/agent-docs/INDEX.md`, never bare relative references like `docs/agent-docs/`. The user works across many repos and machines, so unanchored paths are ambiguous without context.
+12. **Always use `ls -la` (not `ls`) when listing directories for keys, tokens, configs, or credentials.** Hidden (dot-prefixed) files are common for sensitive data — plain `ls` omits them. This applies to any directory likely to hold secrets (e.g., `~/keys/`, `~/.ssh/`, `~/.config/`).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Project repo flow (e.g., ~/vb/ — layers span two repos):
 
 **Layer 1 — Agent-specific entry points.** `CLAUDE.md` (for Claude Code) and `agents.md` (for Codex) live in the repo root. Their content is a single line directing the agent to `~/agents-config/INDEX_RULES.md`. From the home directory, `~/CLAUDE.md` and `~/agents.md` are filesystem symlinks to these files, so the agent finds the same entry point regardless of where it's launched.
 
-**Layer 2 — Global rules & doc routing.** `INDEX_RULES.md` contains two things: (1) global rules that always apply (never commit secrets, verify before pushing, QA gating, etc.) and (2) doc routing that groups docs by topic with concise path-based "references" — file paths written as text (e.g., `~/agents-config/machine/mac.md`) that tell the agent where to look — so the agent only loads what's relevant to the current task.
+**Layer 2 — Tiered rules & doc routing.** `INDEX_RULES.md` contains two things: (1) rules organized into three tiers — **Hard Rules** (every response, never skip: no secrets, QA gating, TLDR, config refresh), **Trigger Rules** (mandatory when triggered: agents-config edits, PRs, GPU jobs), and **Guidelines** (best practices: anchored paths, context efficiency) — and (2) doc routing that groups docs by topic with concise path-based "references" — file paths written as text (e.g., `~/agents-config/machine/mac.md`) that tell the agent where to look — so the agent only loads what's relevant to the current task.
 
 **Layer 3 — Modular scoped docs.** Individual markdown files organized by domain. Each is self-contained and only loaded when relevant. Machine configs, workflow guides, and other scoped docs you choose to add.
 
@@ -105,6 +105,71 @@ ln -s ~/agents-config/agents.md ~/agents.md
 
 # Claude Code will automatically read CLAUDE.md → INDEX_RULES.md
 # Codex will automatically read agents.md → INDEX_RULES.md
+```
+
+---
+
+## Remote Access (Claude Remote Control & Codex)
+
+### Claude Remote Control — per server setup
+
+Remote Control (RC) lets you hand off a Claude Code session to your phone or another device via `claude.ai/code`. It requires a **full claude.ai login** — long-lived env vars like `CLAUDE_CODE_OAUTH_TOKEN` block RC.
+
+On each server (SNAP, Sherlock, etc.):
+
+```bash
+# 1. Find and remove/comment any auth env vars from shell startup
+grep -nH -E 'CLAUDE_CODE_OAUTH_TOKEN|ANTHROPIC_API_KEY|ANTHROPIC_AUTH_TOKEN' \
+  ~/.zshrc ~/.zprofile ~/.bashrc ~/.bash_profile ~/.profile 2>/dev/null
+
+# 2. Unset them in the current session
+unset ANTHROPIC_API_KEY ANTHROPIC_AUTH_TOKEN CLAUDE_CODE_OAUTH_TOKEN \
+  CLAUDE_CODE_OAUTH_REFRESH_TOKEN CLAUDE_CODE_USE_BEDROCK CLAUDE_CODE_USE_VERTEX \
+  CLAUDE_CODE_USE_FOUNDRY CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC DISABLE_TELEMETRY
+
+# 3. Reload shell
+exec zsh  # or: exec bash
+
+# 4. Re-authenticate with full account login (not API key)
+claude auth logout
+claude auth login
+claude auth status --text  # verify: should show claude.ai account, no env overrides
+
+# 5. Start Remote Control
+claude remote-control  # success = Environment ID + Connected + claude.ai/code URL
+```
+
+**Shell config pattern** — keep file-based secrets, but don't auto-export Claude auth:
+
+```bash
+# OK: normal secrets from files
+[ -f "$HOME/keys/brandos_wandb_key.txt" ] && export WANDB_API_KEY="$(cat "$HOME/keys/brandos_wandb_key.txt")"
+
+# DO NOT enable — blocks Remote Control by overriding stored credentials
+# [ -f "$HOME/keys/claude_code_oauth_token.txt" ] && export CLAUDE_CODE_OAUTH_TOKEN="..."
+```
+
+### Codex — no RC equivalent (use tmux)
+
+Codex CLI has no `remote-control` command. Auth is via **ChatGPT login** (interactive) or **API key** (automation). Persistence over SSH uses tmux:
+
+```bash
+# Start a persistent Codex session
+tmux new -As codex
+codex  # sign in with ChatGPT when prompted, or set OPENAI_API_KEY
+
+# Reconnect later from any device
+ssh <server> -t 'tmux attach -t codex'
+```
+
+### Server rollout checklist
+
+```
+[ ] On each server: remove CLAUDE_CODE_OAUTH_TOKEN / ANTHROPIC_API_KEY from shell startup
+[ ] Reload shell, run: claude auth login
+[ ] Verify: claude auth status --text (no env overrides)
+[ ] Start: claude remote-control
+[ ] For Codex: choose ChatGPT login or API key, run inside tmux
 ```
 
 ---


### PR DESCRIPTION
## Summary
- Restructured 13 flat "Global Rules" into 3 tiers: Hard Rules (5), Trigger Rules (3), Guidelines (4)
- Merged old rules 7 (re-read after edit) + 12 (commit/push immediately) into single Trigger Rule 6
- Added inline Mandatory Response Protocol to CLAUDE.md (TLDR, QA gating, no secrets, fresh config)
- Updated README Layer 2 description to reflect tiered structure
- Added Remote Access section to README: Claude RC per-server setup + Codex tmux pattern

## Test plan
- QA correctness review: PASS (all 13 old rules mapped to new 12, cross-refs correct, no secrets)
- Structural QA: skipped (markdown-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)