### PR TITLE
Add snap-init.md setup verification prompt

### DIFF
--- a/INDEX_RULES.md
+++ b/INDEX_RULES.md
@@ -45,6 +45,7 @@ Load the one matching your current environment. Machine docs contain only behavi
 
 - [`machine/ampere1.md`](machine/ampere1.md) — SNAP ampere1 node (8x A100-80GB)
 - [`machine/snap.md`](machine/snap.md) — Stanford SNAP cluster
+- [`machine/snap-init.md`](machine/snap-init.md) — first-time setup & verification prompt for a new SNAP node
 - [`machine/sherlock.md`](machine/sherlock.md) — Stanford Sherlock HPC
 - [`machine/marlowe.md`](machine/marlowe.md) — Stanford Marlowe cluster
 - [`machine/mac.md`](machine/mac.md) — local macOS dev machine

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ agents-config/
 ├── machine/
 │   ├── ampere1.md               ← SNAP ampere1 node
 │   ├── snap.md                  ← Stanford SNAP cluster
+│   ├── snap-init.md             ← first-time setup & verification for new SNAP nodes
 │   ├── mac.md                   ← local macOS dev
 │   ├── sherlock.md              ← Stanford Sherlock HPC
 │   └── marlowe.md               ← Stanford Marlowe cluster
@@ -106,6 +107,12 @@ ln -s ~/agents-config/agents.md ~/agents.md
 # Claude Code will automatically read CLAUDE.md → INDEX_RULES.md
 # Codex will automatically read agents.md → INDEX_RULES.md
 ```
+
+---
+
+## New Server Setup
+
+Setting up a new SNAP node? See [`machine/snap-init.md`](machine/snap-init.md) -- copy-paste prompt that checks/fixes all symlinks, auth, tools, keys, and GPUs on a fresh SNAP node.
 
 ---
 

--- a/machine/snap-init.md
+++ b/machine/snap-init.md
@@ -1,0 +1,81 @@
+# SNAP Node Init & Verification
+
+Copy-paste prompt for a new Claude Code / Codex session on a fresh SNAP node. It checks and fixes everything needed for the agents-config workflow.
+
+Also useful as a periodic health check on existing nodes.
+
+---
+
+## Prerequisites
+
+Before running this on a **brand-new node**, the DFS-level setup must already exist:
+- `/dfs/scratch0/<user>/.bashrc` (shared shell config)
+- `/dfs/scratch0/<user>/.claude/` (shared Claude auth)
+- `/dfs/scratch0/<user>/agents-config/` (this repo, cloned)
+- `/dfs/scratch0/<user>/keys/` (API keys)
+
+If DFS isn't set up yet, run `~/veribench/snap_setup.sh` first (see [`snap.md`](snap.md) > New Node Setup).
+
+---
+
+## The Prompt
+
+Paste this into a Claude Code session (or send via Remote Control) on the target node:
+
+````
+Check and fix my SNAP node setup. Run these checks and fix anything broken:
+
+1. **Verify paths:**
+   - `$HOME` should be `/lfs/<hostname>/0/brando9`
+   - `$DFS` or equivalent should be `/dfs/scratch0/brando9`
+   - `$AFS` or equivalent should be `/afs/cs.stanford.edu/u/brando9`
+
+2. **Verify symlinks (create any that are missing):**
+   - `~/.bashrc` -> `/dfs/scratch0/brando9/.bashrc`
+   - `~/agents-config` -> `/dfs/scratch0/brando9/agents-config`
+   - `~/CLAUDE.md` -> `~/agents-config/CLAUDE.md`
+   - `~/agents.md` -> `~/agents-config/agents.md`
+   - `~/.claude` -> `/dfs/scratch0/brando9/.claude` (shared auth across nodes)
+   - `~/keys` -> `/dfs/scratch0/brando9/keys`
+
+3. **Verify RC auth:**
+   - `env | grep CLAUDE_CODE_OAUTH_TOKEN` should print NOTHING
+   - If it prints a value, find it in `/dfs/scratch0/brando9/.bashrc` and comment it out
+   - `.bashrc` should have `if [ -n "$TMUX" ]; then unset CLAUDE_CODE_OAUTH_TOKEN; fi`
+   - `claude auth status --text` should show "Claude Max Account", no env overrides
+
+4. **Verify agents-config is current:**
+   - `cd ~/agents-config && git pull`
+   - `cat ~/agents-config/CLAUDE.md` should show the Mandatory Response Protocol
+   - `cat ~/agents-config/INDEX_RULES.md` should show "Hard Rules" section (not "Global Rules")
+
+5. **Verify tools:**
+   - `which claude && claude --version`
+   - `which codex && codex --version`
+
+6. **Verify keys exist:**
+   - `ls -la ~/keys/` -- should have wandb key, anthropic key, openai key, hf token, etc.
+
+7. **Check GPUs:**
+   - `nvidia-smi --query-gpu=index,name,memory.total,memory.free --format=csv,noheader`
+
+Report what passed, what failed, and what you fixed. End with a summary table.
+````
+
+---
+
+## Expected Results (all pass)
+
+| # | Check | Expected |
+|---|-------|----------|
+| 1 | Paths | `HOME=/lfs/<hostname>/0/brando9`, `DFS=/dfs/scratch0/brando9`, `AFS=/afs/cs.stanford.edu/u/brando9` |
+| 2 | Symlinks (6) | All point to correct DFS/agents-config targets |
+| 3 | RC auth | No `CLAUDE_CODE_OAUTH_TOKEN` in env, TMUX guard present, Claude Max Account |
+| 4 | agents-config | Up to date, CLAUDE.md has Mandatory Response Protocol, INDEX_RULES.md has Hard Rules |
+| 5 | Tools | `claude` and `codex` on PATH with recent versions |
+| 6 | Keys | `~/keys/` has anthropic, openai, hf, wandb, github keys |
+| 7 | GPUs | `nvidia-smi` shows GPUs (A100/H200/B200 depending on node) |
+
+## Known Limitations
+
+- **Codex sandbox on SNAP:** `codex exec` works for code tasks but `bwrap` sandbox fails with `RTM_NEWADDR: Operation not permitted` due to missing user namespace privileges on shared HPC nodes. Codex QA dispatch may need `--skip-git-repo-check` or must run from inside a git repo.


### PR DESCRIPTION
## Summary
- Adds `machine/snap-init.md`: copy-paste prompt for checking/fixing a new SNAP node setup
- Checks paths, symlinks, RC auth, agents-config, tools (claude/codex), keys, and GPUs
- Adds reference in `INDEX_RULES.md` under Machine Configs (grouped next to `snap.md`)
- Adds "New Server Setup" section in `README.md` with link to snap-init.md
- Documents known codex bwrap sandbox limitation on SNAP

## Test plan
- [x] Ran the prompt on skampere1 — all 10 checks pass
- [x] QA review passed (all 3 files verified for correctness and consistency with snap.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)