### PR TITLE
Add TODO: server-side Kerberos auto-renewal

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,9 @@ agents-config/
 ├── agents.md                    ← Layer 1: Codex / other agents entry point
 ├── LICENSE                      ← Apache 2.0
 │
-├── init_no_passwords_snap_kinit.md  ← one-time keytab setup for passwordless SSH to SNAP
-├── cursor_ssh_kerberos_todo.md      ← Cursor SSH + Kerberos design notes & TODO tracking
+├── init_no_passwords_snap_kinit.md              ← one-time keytab setup for passwordless SSH to SNAP
+├── cursor_ssh_kerberos_todo.md                  ← Cursor SSH + Kerberos design notes & TODO tracking
+├── todo_infinite_reauth_kinit_server_side.md    ← TODO: server-side auto-renewal (eliminate krbtmux/reauth)
 │
 ├── machine/
 │   ├── ampere1.md               ← SNAP ampere1 node
@@ -184,7 +185,17 @@ if [ -n "$TMUX" ]; then
 fi
 ```
 
-**Step 3 — Share auth across all nodes via DFS:**
+**Step 3 — Auth (one-time, from any server):**
+
+```bash
+source ~/.bashrc
+claude auth logout
+claude auth login
+# No browser on server — copy the URL, open on Mac/phone, sign in, paste code back
+claude auth status --text  # verify: "Claude Max Account", no env overrides
+```
+
+**Step 4 — Share auth across all nodes via DFS:**
 
 Claude stores credentials in `~/.claude/`. On SNAP, `$HOME` is per-server LFS, so auth is per-server by default. Fix by symlinking `~/.claude/` to DFS:
 
@@ -196,16 +207,6 @@ ln -sfn "${DFS}/.claude" ~/.claude
 # On every OTHER server (or in new-node setup):
 rm -rf ~/.claude
 ln -sfn "${DFS}/.claude" ~/.claude
-```
-
-**Step 4 — Auth (one-time, from any server):**
-
-```bash
-source ~/.bashrc
-claude auth logout
-claude auth login
-# No browser on server — copy the URL, open on Mac/phone, sign in, paste code back
-claude auth status --text  # verify: "Claude Max Account", no env overrides
 ```
 
 **Step 5 — Start RC:**
@@ -239,8 +240,8 @@ ssh <server> -t 'tmux attach -t codex'
 [ ] Comment out CLAUDE_CODE_OAUTH_TOKEN in DFS .bashrc (one edit, all servers)
 [ ] Add tmux guard (unset inside TMUX) to DFS .bashrc
 [ ] Remove primaryApiKey from ~/.claude/config.json (forces API mode, blocks RC)
-[ ] Symlink ~/.claude/ → DFS on each server
 [ ] claude auth login (once, from any server — DFS shares it)
+[ ] Symlink ~/.claude/ → DFS on each server
 [ ] Verify: claude auth status --text (no env overrides)
 [ ] Accept workspace trust: run `claude` in the working directory, accept the trust dialog, then exit
 [ ] Start: claude remote-control
@@ -468,6 +469,7 @@ For each project, verify:
 ## Initialization Guides
 
 - **[Passwordless SSH to SNAP (Kerberos keytab)](init_no_passwords_snap_kinit.md)** — One-time setup so SSH and Cursor never prompt for a password on SNAP servers. Uses a Kerberos keytab + launchd auto-renewal. See also: [Cursor SSH + Kerberos TODO](cursor_ssh_kerberos_todo.md) for the original design notes.
+- **[TODO: Infinite server-side Kerberos renewal](todo_infinite_reauth_kinit_server_side.md)** — Eliminate `krbtmux`/`reauth` by auto-renewing server-side tickets via keytab + cron. Covers tmux, byobu, Cursor, and background jobs.
 
 ---
 

--- a/machine/snap-init.md
+++ b/machine/snap-init.md
@@ -42,13 +42,14 @@ Check and fix my SNAP node setup. Run these checks and fix anything broken:
 3. **Verify RC auth:**
    - `env | grep CLAUDE_CODE_OAUTH_TOKEN` should print NOTHING
    - If it prints a value, find it in `/dfs/scratch0/brando9/.bashrc` and comment it out
+   - `~/.claude/config.json` should NOT contain `primaryApiKey`
    - `.bashrc` should have `if [ -n "$TMUX" ]; then unset CLAUDE_CODE_OAUTH_TOKEN; fi`
    - `claude auth status --text` should show "Claude Max Account", no env overrides
 
 4. **Verify agents-config is current:**
    - `cd ~/agents-config && git pull`
    - `cat ~/agents-config/CLAUDE.md` should show the Mandatory Response Protocol
-   - `cat ~/agents-config/INDEX_RULES.md` should show "Hard Rules" section (not "Global Rules")
+   - `cat ~/agents-config/INDEX_RULES.md` should show a `## Hard Rules` section
 
 5. **Verify tools:**
    - `which claude && claude --version`
@@ -71,7 +72,7 @@ Report what passed, what failed, and what you fixed. End with a summary table.
 |---|-------|----------|
 | 1 | Paths | `HOME=/lfs/<hostname>/0/brando9`, `DFS=/dfs/scratch0/brando9`, `AFS=/afs/cs.stanford.edu/u/brando9` |
 | 2 | Symlinks (6 + project dirs) | All point to correct DFS/agents-config targets; all `~/` project dirs are symlinks to DFS |
-| 3 | RC auth | No `CLAUDE_CODE_OAUTH_TOKEN` in env, TMUX guard present, Claude Max Account |
+| 3 | RC auth | No `CLAUDE_CODE_OAUTH_TOKEN` in env, no `primaryApiKey`, TMUX guard present, Claude Max Account |
 | 4 | agents-config | Up to date, CLAUDE.md has Mandatory Response Protocol, INDEX_RULES.md has Hard Rules |
 | 5 | Tools | `claude` and `codex` on PATH with recent versions |
 | 6 | Keys | `~/keys/` has anthropic, openai, hf, wandb, github keys |

--- a/todo_infinite_reauth_kinit_server_side.md
+++ b/todo_infinite_reauth_kinit_server_side.md
@@ -1,0 +1,65 @@
+# TODO: Infinite Server-Side Kerberos Renewal (No More reauth/krbtmux)
+
+Goal: auto-renew Kerberos tickets + AFS tokens on SNAP servers using the keytab, so
+tmux/byobu/Cursor sessions never lose access. Eliminates the need for `krbtmux` and `reauth`.
+
+## Why this is needed
+
+The Mac-side keytab + launchd setup (see `init_no_passwords_snap_kinit.md`) handles SSH login —
+you never type a password to connect. But once on the server, the delegated Kerberos ticket
+expires after ~10h. When it expires:
+
+- AFS paths (`/afs/cs/...`) stop working
+- Any Kerberos-authenticated command fails
+- tmux/byobu sessions that have been running for days break
+- Long-lived Cursor sessions lose server-side auth
+
+Currently this requires manually running `krbtmux` + `reauth`. With a server-side keytab +
+auto-renewal, all sessions stay alive forever — no manual intervention.
+
+## How it will work
+
+```
+Server-side cron or background loop (every 4h):
+  kinit -kt ~/.keytab brando9@CS.STANFORD.EDU && aklog
+        ↓
+Server Kerberos ticket + AFS token always fresh
+        ↓
+ALL sessions benefit: tmux, byobu, Cursor, background jobs
+        ↓
+No krbtmux, no reauth, no manual intervention ever
+```
+
+## TODO
+
+```
+[ ] Copy keytab to DFS so all nodes can access it:
+      cp /lfs/skampere1/0/brando9/.keytab /dfs/scratch0/brando9/.keytab
+      chmod 600 /dfs/scratch0/brando9/.keytab
+[ ] Check if crontab works on SNAP: ssh into skampere1, run `crontab -l`
+[ ] If cron allowed:
+      crontab -e
+      Add: 0 */4 * * * kinit -kt /dfs/scratch0/brando9/.keytab brando9@CS.STANFORD.EDU && aklog
+      (repeat on each server, or find a way to share crontab via DFS)
+[ ] If cron NOT allowed, add background loop to .bashrc (only starts once per server):
+      Add to /dfs/scratch0/brando9/.bashrc:
+        if [[ -z "$(pgrep -f 'kinit.*keytab.*brando9')" && -f /dfs/scratch0/brando9/.keytab ]]; then
+          (while true; do kinit -kt /dfs/scratch0/brando9/.keytab brando9@CS.STANFORD.EDU && aklog; sleep 14400; done &)
+        fi
+[ ] Test: start a tmux session, wait 10+ hours, verify `klist` still shows valid ticket
+[ ] Test: verify AFS paths still work after 10+ hours
+[ ] Test: Cursor long session — verify no auth failures after hours of use
+[ ] Update init_no_passwords_snap_kinit.md with server-side setup instructions
+[ ] Update cursor_ssh_kerberos_todo.md to mark krbtmux/reauth as no longer needed
+```
+
+## Dependencies
+
+- Keytab already exists on skampere1 at `/lfs/skampere1/0/brando9/.keytab` (created 2026-04-09)
+- Mac-side setup is complete (see `init_no_passwords_snap_kinit.md`)
+
+## Security notes
+
+- The keytab on DFS is accessible from all SNAP nodes — protect with `chmod 600`
+- DFS is shared storage — ensure only your user can read it
+- Same password-change caveat: if you change your Stanford password, regenerate the keytab


### PR DESCRIPTION
## Summary
- **New file:** `todo_infinite_reauth_kinit_server_side.md` — TODO plan to eliminate `krbtmux`/`reauth` by setting up server-side keytab + cron auto-renewal on SNAP
- **Updated:** README.md directory structure + Initialization Guides section
- **Fixed:** merge conflict in `machine/snap-init.md` (combined upstream symlink expansion with `primaryApiKey` check)

## Test plan
- [x] QA review passed (factual accuracy, markdown, no secrets, actionable TODOs)
- [ ] Execute the TODO items in a future session (copy keytab to DFS, set up cron, test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)