### PR TITLE
Deploy server-side Kerberos auto-renewal on SNAP

### DIFF
--- a/cursor_ssh_kerberos_todo.md
+++ b/cursor_ssh_kerberos_todo.md
@@ -73,9 +73,10 @@ Run jobs inside tmux. If Cursor disconnects, your work survives.
 [x] Verify launchd is running: launchctl list | grep kinit && klist (done 2026-04-09)
 [x] Test passwordless SSH from Mac: ssh -o BatchMode=yes brando9@skampere1 (done 2026-04-09)
 [ ] Test Cursor SSH reconnect to a SNAP server without password prompt
-[ ] On each SNAP server, verify krbtmux + reauth are available at /afs/cs/software/bin/
-[ ] Start using krbtmux + reauth + tmux for all long-running sessions
 [ ] If ControlPersist 8h is too short, increase it
+[x] Server-side auto-renewal deployed — krbtmux/reauth no longer needed (done 2026-04-09)
+    See: todo_infinite_reauth_kinit_server_side.md for details.
+    krenew.sh + .bashrc loop + cron handle all ticket renewal automatically.
 ```
 
 ---

--- a/init_no_passwords_snap_kinit.md
+++ b/init_no_passwords_snap_kinit.md
@@ -286,6 +286,34 @@ ssh brando9@skampere1.stanford.edu echo "SUCCESS - no password needed"
 
 ---
 
+### Part E: Server-side auto-renewal (eliminates krbtmux/reauth)
+
+Parts A-D handle the **Mac side** (SSH login). But server-side tickets also expire after ~10h,
+breaking AFS access in tmux/byobu/Cursor sessions. This part auto-renews server-side tickets.
+
+**What was deployed:**
+1. **Keytab on DFS:** `/dfs/scratch0/brando9/.keytab` (accessible from all nodes)
+2. **`krenew.sh` script:** `/dfs/scratch0/brando9/bin/krenew.sh` — runs `kinit -kt` + `aklog`
+3. **`.bashrc` background loop:** Runs `krenew.sh` on login + spawns a PID-guarded loop every 4h
+4. **Cron (secondary):** `0 */4 * * *` on each node as backup
+
+**Result:** All sessions (tmux, byobu, Cursor, background jobs) have valid Kerberos tickets
+and AFS tokens forever. No more `krbtmux` or `reauth` needed.
+
+**Logs:** `/tmp/krenew_brando9.log` on each server.
+
+**Verify on any node:**
+```bash
+klist                              # valid ticket
+cat /tmp/krenew_brando9.pid        # PID exists
+ps -p $(cat /tmp/krenew_brando9.pid)  # process alive
+tail -3 /tmp/krenew_brando9.log    # recent OK entries
+```
+
+See `~/agents-config/todo_infinite_reauth_kinit_server_side.md` for full details.
+
+---
+
 ## Troubleshooting
 
 | Problem | Fix |

--- a/machine/snap.md
+++ b/machine/snap.md
@@ -21,7 +21,7 @@ ssh <user>@<hostname>.stanford.edu
 - **Access:** Direct SSH from Stanford network or VPN. No jump host.
 - **Port:** 22
 - **Persistent sessions:** Use `byobu` (tmux-based, human-only — agents cannot interact with tmux). Config is shared across nodes via DFS (`BYOBU_CONFIG_DIR` set in `.bashrc`).
-- **Kerberos reauth for persistent sessions:** Kerberos tickets expire (~3 days), breaking AFS access inside detached sessions. Use `/afs/cs/software/bin/krbtmux` (or `krbscreen`) to launch the multiplexer, then run `/afs/cs/software/bin/reauth` inside to keep tickets renewed. See https://ilwiki.stanford.edu/doku.php?id=hints:long-jobs.
+- **Kerberos auto-renewal:** Server-side tickets are auto-renewed every 4h by `krenew.sh` (DFS keytab + `.bashrc` background loop + cron). `krbtmux`/`reauth` are no longer needed for ticket renewal. See `~/agents-config/todo_infinite_reauth_kinit_server_side.md` for details. Fallback: `/afs/cs/software/bin/krbtmux` and `/afs/cs/software/bin/reauth` still work if auto-renewal is not set up. Ref: https://ilwiki.stanford.edu/doku.php?id=hints:long-jobs.
 
 ---
 

--- a/todo_infinite_reauth_kinit_server_side.md
+++ b/todo_infinite_reauth_kinit_server_side.md
@@ -33,24 +33,17 @@ No krbtmux, no reauth, no manual intervention ever
 ## TODO
 
 ```
-[ ] Copy keytab to DFS so all nodes can access it:
-      cp /lfs/skampere1/0/brando9/.keytab /dfs/scratch0/brando9/.keytab
-      chmod 600 /dfs/scratch0/brando9/.keytab
-[ ] Check if crontab works on SNAP: ssh into skampere1, run `crontab -l`
-[ ] If cron allowed:
-      crontab -e
-      Add: 0 */4 * * * kinit -kt /dfs/scratch0/brando9/.keytab brando9@CS.STANFORD.EDU && aklog
-      (repeat on each server, or find a way to share crontab via DFS)
-[ ] If cron NOT allowed, add background loop to .bashrc (only starts once per server):
-      Add to /dfs/scratch0/brando9/.bashrc:
-        if [[ -z "$(pgrep -f 'kinit.*keytab.*brando9')" && -f /dfs/scratch0/brando9/.keytab ]]; then
-          (while true; do kinit -kt /dfs/scratch0/brando9/.keytab brando9@CS.STANFORD.EDU && aklog; sleep 14400; done &)
-        fi
-[ ] Test: start a tmux session, wait 10+ hours, verify `klist` still shows valid ticket
-[ ] Test: verify AFS paths still work after 10+ hours
-[ ] Test: Cursor long session — verify no auth failures after hours of use
-[ ] Update init_no_passwords_snap_kinit.md with server-side setup instructions
-[ ] Update cursor_ssh_kerberos_todo.md to mark krbtmux/reauth as no longer needed
+[x] Copy keytab to DFS (done 2026-04-09): /dfs/scratch0/brando9/.keytab (chmod 600)
+[x] Check if crontab works on SNAP: yes, cron is available (done 2026-04-09)
+[x] Created standalone krenew.sh script at /dfs/scratch0/brando9/bin/krenew.sh (done 2026-04-09)
+[x] Added .bashrc background loop with PID-file guard + disown (done 2026-04-09)
+[x] Added cron (0 */4 * * *) on: skampere1-3, mercury1-2, hyperturing1 (done 2026-04-09)
+[x] Fixed .bashrc nvidia-htop noise for non-interactive shells (done 2026-04-09)
+[x] Multi-node sweep: all 6 nodes pass — ticket valid, PID alive, AFS OK, cron set (done 2026-04-09)
+[x] scp test passed (no more "Received message too long") (done 2026-04-09)
+[ ] Long-duration test: tmux session 10+ hours, verify klist + AFS still work
+[ ] Long-duration test: Cursor SSH session 10+ hours, verify no auth failures
+[ ] Add cron to Slurm-gated nodes (ampere1/8/9, hyperturing2) when jobs are running
 ```
 
 ## Dependencies


### PR DESCRIPTION
## Summary
- Deployed `krenew.sh` + `.bashrc` background loop + cron on all 6 reachable SNAP nodes
- Server-side Kerberos tickets + AFS tokens now auto-renew every 4h via DFS keytab
- `krbtmux`/`reauth` are no longer needed for ticket renewal
- Fixed `.bashrc` nvidia-htop noise for non-interactive shells (was breaking scp)
- Updated all related docs (TODO, cursor_ssh_kerberos_todo, snap.md, init guide)

## Test plan
- [x] DFS keytab tested from skampere1 and mercury1
- [x] krenew.sh runs successfully (log shows "OK renewed")
- [x] .bashrc loop: PID alive, no duplicates on second login
- [x] Cron added on all 6 nodes
- [x] Multi-node sweep: all pass (ticket valid, PID alive, AFS OK, cron set)
- [x] scp test: no "Received message too long" error
- [ ] Long-duration test: tmux 10+ hours (pending)
- [ ] Long-duration test: Cursor 10+ hours (pending)

🤖 Generated with [Claude Code](https://claude.com/claude-code)