### PR TITLE
Standardize GitHub clone fallback across all CLAUDE.md/agents.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,5 @@
 # Claude Code: read `~/agents-config/INDEX_RULES.md` for all agent documentation and routing.
+# If `~/agents-config/` is not present, clone it: `git clone https://github.com/brando90/agents-config.git ~/agents-config`
 
 ## Mandatory Response Protocol (inline — do not skip)
 

--- a/agents.md
+++ b/agents.md
@@ -1,1 +1,2 @@
 # Codex / other agents: read `~/agents-config/INDEX_RULES.md` for all agent documentation and routing.
+# If `~/agents-config/` is not present, clone it: `git clone https://github.com/brando90/agents-config.git ~/agents-config`

--- a/workflows/repo-init.md
+++ b/workflows/repo-init.md
@@ -22,13 +22,14 @@ This checklist covers the **minimal** tier.
 
 ### 1. Add the redirect header to the project's `CLAUDE.md`
 
-The **first line** of the project's `CLAUDE.md` must be:
+The **first two lines** of the project's `CLAUDE.md` must be:
 
 ```
 # Claude Code: read `~/agents-config/INDEX_RULES.md` for all agent documentation and routing.
+# If `~/agents-config/` is not present, clone it: `git clone https://github.com/brando90/agents-config.git ~/agents-config`
 ```
 
-This ensures Claude Code loads global rules before project-specific docs.
+The first line points to the local config. The second line ensures agents running on phones/cloud (via Remote Control or without a local copy) can bootstrap themselves by cloning from GitHub.
 
 ### 2. Add `agents.md` for Codex / other agents
 
@@ -36,6 +37,7 @@ Create `agents.md` in the project root:
 
 ```
 # Codex / other agents: read `~/agents-config/INDEX_RULES.md` for all agent documentation and routing.
+# If `~/agents-config/` is not present, clone it: `git clone https://github.com/brando90/agents-config.git ~/agents-config`
 # Then read `~/PROJECT/CLAUDE.md` for project-specific instructions.
 ```
 
@@ -88,7 +90,18 @@ After migration, verify the full routing chain works:
 
 Track repos that have completed migration:
 
-- [x] `~/veribench/` — migrated 2026-04-02
-- [ ] `~/veribench-dt/` — pending
-- [x] `~/veri-veri-bench/` — migrated 2026-04-07
-- [x] `~/agentic-nl-fl-maths/` — migrated 2026-04-07
+- [x] `~/veribench/` — migrated 2026-04-02, GitHub fallback added 2026-04-10
+- [x] `~/veribench-dt/` — migrated 2026-04-10
+- [x] `~/veribench-deps/` — migrated 2026-04-10
+- [x] `~/veri-veri-bench/` — migrated 2026-04-07, GitHub fallback added 2026-04-10
+- [x] `~/agentic-nl-fl-maths/` — migrated 2026-04-07, GitHub fallback added 2026-04-10
+- [x] `~/cert-judge/` — migrated 2026-04-10
+- [x] `~/formal-6-437/` — migrated 2026-04-10
+- [x] `~/harbor-fork/` — migrated 2026-04-10
+- [x] `~/KoyejoLab-Crucible/` — migrated 2026-04-10
+- [x] `~/KoyejoLab-Memorization-Scoring-vs-Sampling/` — migrated 2026-04-10
+- [x] `~/lean-ebm/` — migrated 2026-04-10
+- [x] `~/no-gold-ref-judge/` — migrated 2026-04-10
+- [x] `~/verina/` — migrated 2026-04-10
+- [x] `~/pass-tests-fail-proofs-/` — migrated 2026-04-07, GitHub fallback added 2026-04-10
+- [x] `~/tvdmi-judge-asymptotics/` — migrated 2026-04-07, GitHub fallback added 2026-04-10


### PR DESCRIPTION
## Summary
- Added GitHub clone fallback URL (`https://github.com/brando90/agents-config.git`) to `CLAUDE.md` and `agents.md` so agents on phones/cloud (Remote Control, Codex) can bootstrap without a local `~/agents-config/` copy
- Updated `workflows/repo-init.md` with the new 2-line standard header and marked all 15 migrated repos as complete
- All 15 project repos (`cert-judge`, `formal-6-437`, `harbor-fork`, `veribench`, `veribench-dt`, `veribench-deps`, `veri-veri-bench`, `verina`, `agentic-nl-fl-maths`, `pass-tests-fail-proofs-`, `tvdmi-judge-asymptotics`, `KoyejoLab-Crucible`, `KoyejoLab-Memorization-Scoring-vs-Sampling`, `lean-ebm`, `no-gold-ref-judge`) were updated and pushed separately

## Test plan
- [x] Verified all 15 repos have the 2-line CLAUDE.md header with GitHub fallback
- [x] Verified all 15 repos have agents.md with GitHub fallback
- [x] Codex QA pass on agents-config diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)