### PR TITLE
Clarify writing guide: no CS197 jargon in paper prose

### DIFF
--- a/writing/ml_research_writing.md
+++ b/writing/ml_research_writing.md
@@ -16,13 +16,18 @@ You are a top ML researcher writing for elite venues (NeurIPS, ICML, ICLR). You 
 
 ---
 
-## Core Principle: The Bit Flip
+## Core Principle: Challenging Assumptions
 
-A good heuristic for impactful research writing:
+<!-- "Bit flip" is CS 197 teaching jargon for this concept. Use it ONLY as
+     internal shorthand / LaTeX comments (% bit flip: ...) to organize your
+     thinking.  NEVER write "bit flip" in actual paper prose. The published
+     text must read as normal professional scientific writing. -->
 
-> **Optimize for Novelty/Innovation (= contribution). Maximize surprise ~ Bit Flip!**
+A good heuristic for structuring an impactful contribution:
 
-Identify the assumption in prior work → flip it → that's your contribution. The bit flip is the atom of your paper's narrative.
+> Identify a widely held assumption in prior work → show why it is wrong or incomplete → introduce your approach that overturns it.
+
+This assumption-inversion is the narrative spine of the paper. Use it to plan structure (e.g., `% assumption to challenge: ...` comments in `.tex`), but the prose itself should simply present the problem, the gap, and your solution in clear, professional language — no meta-commentary about "flipping" anything.
 
 ---
 
@@ -35,9 +40,9 @@ The abstract is critical — Title + Abstract may be all people read. Apply the 
 Each point gets 1–2 sentences in the abstract (vs. a full paragraph in the intro):
 
 1. **Problem motivation:** State the problem and why it matters. Optionally why it hasn't been solved.
-2. **Set up the bit/assumption:** Identify the assumption in prior work you're challenging.
-3. **Flip the bit (= contribution):** Introduce your novel idea that inverts the assumption. Immediate, surprising hook — not a slow multi-sentence buildup.
-4. **Instantiate the bit flip (= your solution):** Describe how your solution concretely applies the new idea. Factual, comprehensive, extremely succinct/direct.
+2. **Prior assumption / gap:** Identify the assumption or limitation in prior work that your paper challenges.
+3. **Your contribution:** Introduce your novel idea that addresses the gap. Lead with surprise — immediate hook, not a slow multi-sentence buildup.
+4. **Approach / solution:** Describe how your solution concretely works. Factual, comprehensive, extremely succinct/direct.
 5. **Evaluation:** Briefly mention your evaluation method and key result. Use concrete numbers, not placeholders.
 6. **Implications:** Broader perspective and significance. Vision, not self-congratulation.
 
@@ -57,6 +62,7 @@ Each point gets 1–2 sentences in the abstract (vs. a full paragraph in the int
 - [Stanford paper writing tips — Abstract](https://cs.stanford.edu/people/widom/paper-writing.html#abstract)
 - [Nature summary paragraph guide](https://www.nature.com/documents/nature-summary-paragraph.pdf)
 - [arXiv:2304.15004](https://arxiv.org/abs/2304.15004)
+- [VeriBench paper_latex/](https://github.com/brando90/veribench/tree/main/paper_latex) — original source for this guide's examples and structure
 
 ---
 
@@ -65,9 +71,9 @@ Each point gets 1–2 sentences in the abstract (vs. a full paragraph in the int
 The intro expands the same 6-point structure from the abstract, dedicating a full paragraph to each point:
 
 1. **Problem motivation** — full paragraph establishing the problem and its importance
-2. **Set up the bit/assumption** — paragraph on what prior work assumes
-3. **Flip the bit** — paragraph introducing your contribution
-4. **Instantiate the bit flip** — paragraph on your concrete solution/approach
+2. **Prior assumption / gap** — paragraph on what prior work assumes or misses
+3. **Your contribution** — paragraph introducing your novel idea
+4. **Approach / solution** — paragraph on your concrete method
 5. **Evaluation** — paragraph on methodology and key findings
 6. **Implications** — paragraph on broader impact and significance
 


### PR DESCRIPTION
## Summary
- "Bit flip" is CS 197 teaching jargon — useful for planning but must never appear in published paper text
- Renamed section "Core Principle: The Bit Flip" → "Core Principle: Challenging Assumptions"
- Added explicit HTML comment warning: use bit-flip only in LaTeX `%` comments for planning, never in prose
- Renamed abstract/intro structure labels to professional equivalents ("Flip the bit" → "Your contribution", "Set up the bit/assumption" → "Prior assumption / gap", etc.)
- Added veribench paper_latex/ as source reference link

## Test plan
- [ ] Read `writing/ml_research_writing.md` end-to-end — no "bit flip" in any instruction that could end up in paper output
- [ ] Verify the 6-point structure still reads coherently with new labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)