### PR TITLE
Mega QA: repo-health audit — gitignore, stale rule refs, README tree drift

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,16 @@ machine/private/
 
 # Secrets
 .env
+.env.*
+!.env.example
+!.env.template
 *.secret
 *.key
+*.pem
+*.p12
+*.pfx
+*.token
+keys/
 
 # OS junk
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -12,8 +12,14 @@ Thumbs.db
 *~
 .*.swp
 
+# NFS orphan/lock files left behind when an open file is unlinked
+.nfs*
+
 # Editor
 .vscode/
 .idea/
 *.code-workspace
 !bm-agents-config.code-workspace
+
+# Private business sub-projects (kept locally, not part of public agents-config)
+ai-for-lean-site/

--- a/.nfs000000000616dcbf0000003d
+++ b/.nfs000000000616dcbf0000003d
@@ -1,5 +1,0 @@
-{
-  "model": "opus",
-  "skipDangerousModePermissionPrompt": true,
-  "effortLevel": "high"
-}

--- a/INDEX_RULES.md
+++ b/INDEX_RULES.md
@@ -112,13 +112,15 @@ Every SNAP node must have these symlinks in `$HOME` (LFS). Missing symlinks caus
 Load the one matching your current environment. Machine docs contain only behavioral constraints and gotchas — not discoverable specs. Run bash commands (`uname -m`, `nvidia-smi`, etc.) to inspect hardware at runtime.
 
 - [`machine/ampere1.md`](machine/ampere1.md) — SNAP ampere1 node (8x A100-80GB)
+- [`machine/mercury1.md`](machine/mercury1.md) — SNAP mercury1 node (10x A4000-16GB)
 - [`machine/mercury2.md`](machine/mercury2.md) — SNAP mercury2 node (10x RTX A4000-16GB)
+- [`machine/skampere1.md`](machine/skampere1.md) — SNAP skampere1 node
+- [`machine/skampere2.md`](machine/skampere2.md) — SNAP skampere2 node
 - [`machine/snap.md`](machine/snap.md) — Stanford SNAP cluster
 - [`machine/snap-init.md`](machine/snap-init.md) — first-time setup & verification prompt for a new SNAP node
 - [`machine/sherlock.md`](machine/sherlock.md) — Stanford Sherlock HPC
 - [`machine/marlowe.md`](machine/marlowe.md) — Stanford Marlowe cluster
 - [`machine/mac.md`](machine/mac.md) — local macOS dev machine
-- [`machine/mercury1.md`](machine/mercury1.md) — SNAP mercury1 node (10x A4000-16GB)
 
 ## Workflows
 
@@ -134,4 +136,4 @@ Load the one matching your current environment. Machine docs contain only behavi
 
 ## Writing
 
-- [`writing/ml_research_writing.md`](writing/ml_research_writing.md) — ML research paper writing guide (persona, abstract structure, LaTeX rules). **Loaded by Trigger Rule 12** when editing `.tex` files.
+- [`writing/ml_research_writing.md`](writing/ml_research_writing.md) — ML research paper writing guide (persona, abstract structure, LaTeX rules). **Loaded by Trigger Rule 13** when editing `.tex` files.

--- a/README.md
+++ b/README.md
@@ -74,21 +74,33 @@ agents-config/
 ├── agents.md                    ← Layer 1: Codex / other agents entry point
 ├── LICENSE                      ← Apache 2.0
 │
+├── claude-code-settings.json    ← shared Claude Code settings (symlinked to ~/.claude/settings.json on each machine)
+├── setup_gemini_cli.sh          ← one-shot installer for the `gemini` CLI (OAuth on Mac, --api-key on servers)
+├── email-signature.md           ← canonical email signature + default From/CC for outbound mail
+├── bm-agents-config.code-workspace  ← VS Code multi-root workspace for editing this repo
+│
 ├── init_no_passwords_snap_kinit.md              ← one-time keytab setup for passwordless SSH to SNAP
 ├── cursor_ssh_kerberos_todo.md                  ← Cursor SSH + Kerberos design notes & TODO tracking
+├── codex_remote_control_todo.md                 ← Codex remote-control TODO / open questions
+├── todo_codex_qa_on_snap.md                     ← TODO: cross-agent QA on SNAP via Codex
 ├── todo_infinite_reauth_kinit_server_side.md    ← TODO: server-side auto-renewal (eliminate krbtmux/reauth)
+├── todo_self_improving_agents_config.md         ← TODO: self-improving feedback loop for this repo
+├── koyejo_stair_cluster_guide.md                ← Koyejo lab / STAIR cluster onboarding & gotchas
 │
-├── machine/
-│   ├── ampere1.md               ← SNAP ampere1 node
+├── machine/                     ← Layer 3: per-machine configs (loaded on demand)
+│   ├── ampere1.md               ← SNAP ampere1 node (8x A100-80GB)
 │   ├── mercury1.md              ← SNAP mercury1 node (10x A4000-16GB)
 │   ├── mercury2.md              ← SNAP mercury2 node (10x A4000-16GB)
+│   ├── skampere1.md             ← SNAP skampere1 node
+│   ├── skampere2.md             ← SNAP skampere2 node
 │   ├── snap.md                  ← Stanford SNAP cluster
 │   ├── snap-init.md             ← first-time setup & verification for new SNAP nodes
+│   ├── snap_setup.sh            ← scripted SNAP-node bootstrap (symlinks, auth, tools)
 │   ├── mac.md                   ← local macOS dev
 │   ├── sherlock.md              ← Stanford Sherlock HPC
 │   └── marlowe.md               ← Stanford Marlowe cluster
 │
-├── workflows/
+├── workflows/                   ← Layer 3: reusable workflows (loaded on demand)
 │   ├── qa-correctness.md        ← cross-agent QA review (correctness + structural)
 │   ├── qa-structural.md         ← structural QA reference (metrics, checks)
 │   ├── expts-and-results.md     ← experiment structure and results reporting
@@ -99,8 +111,22 @@ agents-config/
 │   ├── tweprints.md             ← tweet thread format
 │   └── blog-posts.md            ← SAIL-style blog posts
 │
-├── writing/
+├── writing/                     ← Layer 3: reusable writing guides (loaded on demand)
 │   └── ml_research_writing.md   ← ML research paper writing guide for `.tex` edits
+│
+├── scripts/                     ← shared shell helpers (referenced by hooks and workflows)
+│   ├── auto-update-tools.sh     ← Claude Code SessionStart hook: keeps `claude` / `codex` / `gemini` fresh
+│   ├── ssh-submit.sh            ← SSH fire-and-forget remote-job submitter
+│   ├── git-inbox-poller.sh      ← phone-dispatch poller for `jobs-inbox/`
+│   └── relink-dfs-projects.sh   ← rebuild DFS-backed project symlinks on a fresh node
+│
+├── experiments/                 ← versioned experiment prompts and analysis
+│   ├── experiment_template_readme.tex
+│   ├── 00_refactor_qa_gate/     ← Experiment 00: QA-gate refactor study
+│   └── 01_self_hosted_openclaw/ ← Experiment 01: self-hosted OpenClaw admin-email triage
+│
+├── jobs-inbox/                  ← phone → git-inbox dispatch directory (pending/, dispatched/)
+│   └── README.md
 │
 └── tests/
     └── dummy_experiment/        ← workflow validation (tiny MLP + W&B)

--- a/workflows/expts-and-results.md
+++ b/workflows/expts-and-results.md
@@ -328,7 +328,7 @@ Experiment plan at: experiments/<NN>_<name>/experiment_plan.md
 
 ## Big-Task Notification (MANDATORY for non-experiment "big" tasks)
 
-Per INDEX_RULES Trigger Rule 12, email `brando.science@gmail.com` (CC `brando9@stanford.edu`) when a "big" user-assigned task finishes — not just experiments. Use the same send mechanics as experiment emails: send immediately via the project's `SMTPNotifier` or the Gmail MCP tool; if neither works, use `scripts/send_pending_emails.py` as fallback. Do not draft it. Send it.
+Per INDEX_RULES Trigger Rule 14, email `brando.science@gmail.com` (CC `brando9@stanford.edu`) when a "big" user-assigned task finishes — not just experiments. Use the same send mechanics as experiment emails: send immediately via the project's `SMTPNotifier` or the Gmail MCP tool; if neither works, use `scripts/send_pending_emails.py` as fallback. Do not draft it. Send it.
 
 ### What counts as a "big" task
 


### PR DESCRIPTION
## Summary

- **Untracked NFS orphan.** `.nfs000000000616dcbf0000003d` was an orphaned NFS lock file (an old copy of `claude-code-settings.json`) accidentally committed in WIP snapshot `33d30c2`. Removed from tracking and added `.nfs*` to `.gitignore`.
- **Private subproject leak guard.** `ai-for-lean-site/` (private business sub-project, IP not for public agents-config) was sitting untracked in the working tree. Added to `.gitignore` so it can't be accidentally committed.
- **Defensive secret patterns** (from Codex stage of mega QA): added `.env.*` (with `!.env.example`/`!.env.template` allowlist), `*.pem`, `*.p12`, `*.pfx`, `*.token`, `keys/` to `.gitignore`. No tracked file matches any of these.
- **Stale rule cross-references fixed.** `INDEX_RULES.md` said `writing/ml_research_writing.md` was loaded by "Trigger Rule 12" — but Trigger Rule 12 is "Clean up idle background processes"; the LaTeX rule is Trigger Rule 13. `workflows/expts-and-results.md` cited "Trigger Rule 12" for the Big-Task email — that's Trigger Rule 14. Both fixed.
- **README directory tree updated.** Added missing `scripts/`, `experiments/`, `jobs-inbox/` directories; missing top-level helpers (`claude-code-settings.json`, `setup_gemini_cli.sh`, `email-signature.md`, `bm-agents-config.code-workspace`); newer TODO docs; and `machine/skampere1.md`, `skampere2.md`, `snap_setup.sh`.
- **INDEX_RULES Machine Configs listing** now includes `machine/skampere1.md` and `machine/skampere2.md`.

## Test plan

- [x] All internal markdown links resolve (Python walker over every tracked `.md`, fenced code blocks excluded — 0 broken).
- [x] Mega QA chain Codex → CC → Gemini ran (markdown-only repo, structural skipped). Final verdict from Gemini: PASS, 0 critical / 0 major.
- [x] `git ls-files | grep -E '\\.(env|pem|p12|pfx|token)$|^keys/'` returns no matches — new gitignore patterns don't affect any tracked file.
- [x] Rule cross-references re-validated: every "Hard Rule N" / "Trigger Rule N" / "Guideline N" reference points to the correct rule.

## Appendix

### Mega QA chain results

| Stage | Reviewer | Verdict | Notes |
|---|---|---|---|
| 1 | Codex (`codex exec --full-auto`) | FIXED (3 major / 3 fixes) | Kept the gitignore secrets-pattern improvements; reverted the README full-rewrite (violated "fix don't rewrite" rule) and the `snap_setup.sh` addition to INDEX_RULES Machine Configs (that section is for behavioral docs, not scripts). |
| 2 | CC self-review | clean | Re-ran link checker, re-validated rule refs, confirmed no tracked file matches new gitignore patterns. |
| 3 | Gemini (`gemini -p`) | **PASS** (0 / 0 / 0) | "Repository health is excellent with 100% link resolution, consistent rule cross-referencing, and accurate directory documentation." |

### Out of scope (noted, not changed)

- `INDEX_RULES.md` rule numbers collide between sections (Hard Rules 6–7 vs Trigger Rules 6–7; Trigger 14–15 vs Guidelines 14–15). Cross-references disambiguate by category prefix, so this is not breaking — but a future PR could renumber for clarity.
- `experiments/01_self_hosted_openclaw/cc_prompt.md` references "Hard Rule #5" for the refresh-config rule and "Hard Rule #13" for emailing big tasks — these were correct when the prompt was written but Hard Rules have since been re-shuffled (refresh is now #6; the email rule is Trigger Rule 14, not a Hard Rule). Frozen experiment prompts left alone per QA scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)