### PR TITLE
Experiment 02: QA polling vs truthfulness — control/treatment/routed prompts + bench

### DIFF
--- a/experiments/02_qa_polling_truthfulness/README.md
+++ b/experiments/02_qa_polling_truthfulness/README.md
@@ -89,7 +89,7 @@ See `analysis.md` for full breakdown.
 ## Quick-start
 
 ```bash
-# Cheap, repo-specific (~30 min, ~1k tokens/PR):
+# Cheap, repo-specific (~30 min, ~1.5M tokens total = ~150k/PR across V1+V2+V3):
 python ~/agents-config/experiments/02_qa_polling_truthfulness/bench/run_ac_self_audit.py \
     --n 10 --out ~/dfs/qa-polling-results/ac-self/
 

--- a/experiments/02_qa_polling_truthfulness/README.md
+++ b/experiments/02_qa_polling_truthfulness/README.md
@@ -79,9 +79,10 @@ See `analysis.md` for full breakdown.
 - `prompts/qa_v2_verifier_first.md` — single best-model + mandatory verifier; treatment arm.
 - `prompts/qa_v3_verifier_routed.md` — adaptive: code+tests → ensemble OK, otherwise → single+grounding.
 - `bench/README.md` — how to run.
-- `bench/run_swe_slice.sh` — SWE-bench Verified slice runner (default 20 instances).
-- `bench/run_ac_self_audit.py` — replays N past `agents-config` PRs through V1 vs V2.
-- `bench/vibe_check.py` — selects 5 best/worst examples for Brando's eyeball pass + auto-agreement.
+- `bench/run_swe_slice.sh` — SWE-bench Verified slice runner (default 20 instances). Tier 2.
+- `bench/run_ac_self_audit.py` — replays N past `agents-config` PRs through V1 vs V2 vs V3. Tier 1.
+- `bench/run_bug_injection.py` — plants known bugs in past PRs to measure the H3 miss-rate. Tier 3.
+- `bench/vibe_check.py` — selects K best/worst examples for Brando's eyeball pass + auto-agreement.
 
 ---
 
@@ -95,6 +96,10 @@ python ~/agents-config/experiments/02_qa_polling_truthfulness/bench/run_ac_self_
 # Vibe check (writes 5 best/worst examples for human inspection):
 python ~/agents-config/experiments/02_qa_polling_truthfulness/bench/vibe_check.py \
     --in ~/dfs/qa-polling-results/ac-self/ --out ~/dfs/qa-polling-results/vibe/
+
+# Adversarial: plant known bugs in past PRs and see what V1 / V2 catch (Tier 3):
+python ~/agents-config/experiments/02_qa_polling_truthfulness/bench/run_bug_injection.py \
+    --n 20 --out ~/dfs/qa-polling-results/bug-injection/
 
 # Public benchmark (slower, ~2-4h, requires SWE-bench-Verified env):
 bash ~/agents-config/experiments/02_qa_polling_truthfulness/bench/run_swe_slice.sh \

--- a/experiments/02_qa_polling_truthfulness/README.md
+++ b/experiments/02_qa_polling_truthfulness/README.md
@@ -1,0 +1,113 @@
+# Experiment 02 — QA Polling vs Truthfulness
+
+**TLDR:** Paper "Consensus is Not Verification" (arXiv 2603.06612) shows that polling
+multiple LLM samples does not improve truthfulness in verifier-absent domains
+because LLM errors are structurally correlated. Our mega-QA (Codex → CC → Gemini
+sequential chain with fix authority) overlaps with that failure mode for
+markdown/config/prose changes (no verifier) but diverges for source-code changes
+(tests act as verifier). This experiment quantifies whether mega-QA is actually
+adding value over a single best-model reviewer in our workflow, both on a public
+benchmark (SWE-bench Verified slice) and on our own past PRs (ac-self-audit),
+with a paired vibe-check so the quantitative number can be cross-checked against
+Brando's own qualitative judgment.
+
+---
+
+## Why this exists
+
+Today's gate (`~/agents-config/workflows/qa-correctness.md` Hard Rule 3 + mega
+QA Trigger Rule 10) defaults to:
+
+- **Default QA:** dispatch one independent reviewer (cross-model).
+- **Mega QA:** sequential 3-stage chain (Codex → CC → Gemini), each reviewer
+  reads the prior reviewer's fixes and applies its own.
+
+The paper's argument: aggregation over correlated samples does not produce a
+verifier. Even on 10,000 random ASCII strings (zero ground-truth signal),
+inter-model agreement was κ ≈ 0.35 — correlated *priors*, not correlated
+*knowledge*. Confidence tracks the crowd, not the truth. Surprisingly Popular
+flips sign across tasks. The boundary the paper draws: scaling helps only when
+an external verifier exists.
+
+So the natural question for our workflow: which of our QA invocations actually
+pass through a verifier, and which are pure cross-model voting under another
+name?
+
+---
+
+## Hypotheses
+
+| ID | Statement | Falsifiable? |
+|----|-----------|---|
+| H1 | On code-only diffs with a runnable test suite, mega-QA's PR pass-rate ≈ single-best-model + tests at lower cost. | Yes — measure on SWE-bench Verified slice. |
+| H2 | On markdown/config-only diffs, mega-QA's "issues caught" ≈ single best model; the extra 2 reviewers mostly co-sign. | Yes — ac-self-audit on past markdown-only PRs. |
+| H3 | On a manufactured set of subtly-bad PRs (planted bugs / planted bad rule edits), all 3 reviewers miss the same ≥30% of cases. | Yes — bug-injection variant of ac-self-audit. |
+| H4 | High inter-reviewer agreement on hard questions correlates with shared blind spots, not correctness — usable as a *defer signal*, not a *pass signal*. | Yes — measure agreement vs ground-truth when ground truth exists. |
+
+If H1+H2 hold, we should keep cross-agent QA only when the diff touches
+verifiable code, and fall back to single-best-model + grounding (links/tests)
+otherwise.
+
+---
+
+## Paper setting vs ours (one-glance)
+
+| Axis | Paper | Our mega-QA |
+|------|-------|---|
+| Aggregation | Parallel, K=5–25 samples | Sequential, K=3 stages |
+| Decision rule | Vote / pick most-confident | Each reviewer fixes; last verdict wins |
+| Models | Same/similar family, same prompt | Cross-vendor (OpenAI/Anthropic/Google) |
+| Verifier | None (HLE / BoolQ / Com2Sense / forecasting) | Test suite *when run* — often skipped on docs/config |
+| Outcome predicted by paper | Aggregation ≈ single sample, sometimes worse | Open question — depends on whether tests run |
+
+**Where paper most clearly applies to us:** markdown/config-only PRs in
+agents-config itself (no tests, no verifier, all judgment). That is a *lot* of
+our PRs.
+
+**Where paper least clearly applies:** source-code PRs in `~/veribench/`,
+`~/ultimate-utils/` etc. where tests/lint/type-check provide an external
+verifier *if the reviewer actually runs them*.
+
+See `analysis.md` for full breakdown.
+
+---
+
+## What's in this directory
+
+- `analysis.md` — full paper-vs-ours diff, design decisions, threats to validity.
+- `prompts/qa_v1_polling_baseline.md` — current mega-QA, restated as the control arm.
+- `prompts/qa_v2_verifier_first.md` — single best-model + mandatory verifier; treatment arm.
+- `prompts/qa_v3_verifier_routed.md` — adaptive: code+tests → ensemble OK, otherwise → single+grounding.
+- `bench/README.md` — how to run.
+- `bench/run_swe_slice.sh` — SWE-bench Verified slice runner (default 20 instances).
+- `bench/run_ac_self_audit.py` — replays N past `agents-config` PRs through V1 vs V2.
+- `bench/vibe_check.py` — selects 5 best/worst examples for Brando's eyeball pass + auto-agreement.
+
+---
+
+## Quick-start
+
+```bash
+# Cheap, repo-specific (~30 min, ~1k tokens/PR):
+python ~/agents-config/experiments/02_qa_polling_truthfulness/bench/run_ac_self_audit.py \
+    --n 10 --out ~/dfs/qa-polling-results/ac-self/
+
+# Vibe check (writes 5 best/worst examples for human inspection):
+python ~/agents-config/experiments/02_qa_polling_truthfulness/bench/vibe_check.py \
+    --in ~/dfs/qa-polling-results/ac-self/ --out ~/dfs/qa-polling-results/vibe/
+
+# Public benchmark (slower, ~2-4h, requires SWE-bench-Verified env):
+bash ~/agents-config/experiments/02_qa_polling_truthfulness/bench/run_swe_slice.sh \
+    --n 20 --out ~/dfs/qa-polling-results/swe-slice/
+```
+
+---
+
+## References
+
+- Paper (this experiment's motivator): "Consensus is Not Verification: Why
+  Crowd Wisdom Strategies Fail for LLM Truthfulness," arXiv:2603.06612.
+- Existing QA workflow: `~/agents-config/workflows/qa-correctness.md`.
+- Existing structural QA: `~/agents-config/workflows/qa-structural.md`.
+- Sibling experiment: `~/agents-config/experiments/00_refactor_qa_gate/`
+  (SlopCodeBench + RAMP — degradation gate, complementary motivation).

--- a/experiments/02_qa_polling_truthfulness/analysis.md
+++ b/experiments/02_qa_polling_truthfulness/analysis.md
@@ -1,0 +1,282 @@
+# Experiment 02 — Analysis: Paper Setting vs Our QA
+
+**TLDR:** This document maps "Consensus is Not Verification" (arXiv 2603.06612)
+onto our mega-QA workflow, lists where the paper's findings transfer cleanly
+(markdown/config/prose PRs with no verifier) and where they don't (code PRs
+with a runnable test suite), and specifies the experiments that would tell us
+whether to keep, retire, or route around the current 3-judge chain.
+
+---
+
+## 1. What the paper actually shows
+
+Five aggregation methods (majority vote, highest confidence, confidence-weighted,
+prediction-weighted, Surprisingly Popular) tested across HLE, BoolQ, Com2Sense,
+and a new forecasting benchmark (Predict-the-Future). Five open-source models,
+4B–235B params. At 25× the inference cost of one sample, no method consistently
+beats single-sample baselines on truthfulness. On forecasting where outcomes
+postdate the cutoff, all methods are at chance.
+
+**Mechanism (the structural part):**
+
+1. Wisdom-of-crowds requires roughly independent errors. LLMs share training
+   data, objectives, and post-training incentives — errors are highly
+   correlated. On 53% of MATH questions where multiple models err, they
+   converge on the *same* wrong answer. Temperature variation (0.7 vs 1.0)
+   only flipped plurality answers in 2.9% of cases.
+
+2. The "no-signal" experiment is the cleanest demonstration: 10k random
+   32-character ASCII strings, forced multiple-choice A/B/C/D. Zero ground
+   truth signal. Inter-model κ as high as 0.35, structure stable across
+   temperatures. So the correlation is *prior*, not *knowledge*.
+
+3. Confidence tracks the crowd, not the truth. Surprisingly Popular requires
+   an "expert minority" structure that LLM populations don't reliably have;
+   the diagnostic inverse-SP hits 80% on HLE but is at chance elsewhere — so
+   the signal flips sign across tasks and can't function as a verifier.
+
+**Boundary the paper draws (verbatim summary):** scaling truthfulness via
+inference-time methods helps only when an external verifier exists (proof
+checkers, code execution, etc.). In verifier-absent domains, the levers are:
+external grounding (retrieval, tools, human feedback), genuinely diverse
+training, or explicit verifiers trained on labeled evidence.
+
+**Constructive use of consensus:** not as a *selector*, as a *warning sign* —
+high agreement on hard questions flags shared blind spots and should trigger
+deferral / retrieval.
+
+---
+
+## 2. What our QA actually does
+
+Defined in `~/agents-config/workflows/qa-correctness.md` (Hard Rule 3) and
+mega QA in `~/agents-config/INDEX_RULES.md` Trigger Rule 10:
+
+- **Default:** A1 builds → dispatch one cross-agent reviewer A2 (Codex / CC /
+  Gemini), reviewer fixes what it finds, returns single verdict.
+- **Mega QA:** sequential 3-stage chain (Codex → CC → Gemini if CC built; or
+  CC → Codex → Gemini if Codex built). Each stage reads the prior stage's
+  improved code and adds its own fixes. Last verdict wins.
+
+Important: it is **sequential with fix authority**, not parallel-then-vote.
+That matters.
+
+---
+
+## 3. Where the paper's findings transfer to us
+
+### 3a. Markdown / config / prose PRs (no verifier) — paper applies
+
+Most of our agents-config PRs touch only markdown (rules, workflows, machine
+docs, README, blog drafts). There is no test suite. Reviewers cannot execute
+anything. The signal each reviewer produces is "this seems right" — exactly
+the verifier-absent regime the paper analyzes.
+
+Predicted failure mode: stages 2 and 3 mostly co-sign stage 1. Where stage 1
+embedded a confident-but-wrong claim ("RAMP says X"), stages 2/3 are *more
+likely* to ratify it than to challenge it, because the confident framing
+matches the priors all three were trained on. Inter-stage κ on judgment
+questions about prose is plausibly close to the paper's 0.35 floor even on
+random text.
+
+**This is where the paper most clearly indicts our mega-QA.** An overconfident
+single-model verdict that has been ratified twice will look more authoritative
+than the same verdict from a single model — but the marginal ratifications add
+no real verification, just compute.
+
+### 3b. Source-code PRs *if* tests are run — paper does not directly apply
+
+If the reviewer actually runs the test suite on each fix, tests are an
+external verifier. The reviewer is then doing what the paper allows
+("verifier-anchored scaling"): generate candidates, filter by verifier. The
+3-stage chain becomes 3 independent attempts to find regressions/missing
+edges, each gated by `pytest` etc. Sequential improvement is preserved.
+
+Predicted behavior: mega-QA usefully catches more real issues than single QA,
+because each stage's *fix attempts* are gated by the verifier. The
+ratification problem from §3a is largely defanged by the fact that "looks
+good to me" is replaced by "tests pass."
+
+**Caveat:** in practice, our reviewers often skip running the test suite on
+agents-config-style repos because there's nothing to run, or skip on code
+repos because the tests are slow / require GPU / require auth. When tests are
+skipped, the stage degrades to the §3a regime — pure judgment.
+
+### 3c. Source-code PRs without tests — paper applies
+
+Same as §3a in effect: judgment-only, no verifier. The paper's argument
+applies in full. This is also the regime where structural-QA
+(`workflows/qa-structural.md`) operates without a clear verifier — though
+metrics like CC, erosion, verbosity are partial verifiers because they're
+deterministic measurements rather than judgment.
+
+---
+
+## 4. Where our setup *differs* from the paper (and might still help)
+
+| Difference | Likely effect on the paper's conclusion |
+|---|---|
+| Sequential, not parallel | Reduces correlated-vote problem, since later stages SEE earlier outputs and might disagree explicitly. But also introduces anchoring: stage 2/3 read stage 1's framing first. |
+| Each reviewer FIXES, not votes | Real fixes are real progress regardless of correlation. One reviewer correctly catching a logic bug is a win. |
+| Cross-vendor (OpenAI/Anthropic/Google) | Paper's open-source family showed κ≈0.35 on no-signal. Cross-vendor agreement is plausibly lower but unmeasured for our models specifically. |
+| Reviewer can read tests/lint/CI output | Adds verifier, when used. |
+| Single-model fallback already specified | Workflow already degrades gracefully when only one CLI is logged in. |
+
+The honest summary: mega-QA *is not* the parallel-vote setup the paper
+disproves, but it shares enough mechanism (correlated priors, judgment-only
+verdicts on prose) that we should not assume it inherits the benefits of true
+verification just because it costs 3× more.
+
+---
+
+## 5. Constructive use of the paper
+
+The paper's final-section suggestion — high consensus on hard questions as a
+**deferral signal** — fits our workflow naturally. Concrete uses:
+
+1. **Inter-stage agreement metric.** When all 3 mega-QA stages return PASS on
+   a non-trivial diff with no fixes applied, that should *not* shorten Brando's
+   review — it should flag "high agreement on a non-trivial diff: possible
+   shared blind spot, please double-check yourself or pull a human reviewer."
+
+2. **Anti-anchoring stage.** Add a stage 0 "naive" pass that does not see the
+   diff's commit message or PR title, only the raw `git diff`. Compare its
+   verdict to stage 3's. Wide divergence → likely framing-driven; converged
+   pass → either truly clean or shared bias.
+
+3. **Cite-or-die for prose changes.** For markdown/config-only diffs, require
+   the reviewer to produce at least one citation (file:line or external URL)
+   per claim it ratifies. No citation → flag as "judgment only — bias risk."
+
+---
+
+## 6. Proposed experiments
+
+### Tier 1: AC-self-audit (cheap, repo-specific, fast)
+
+**What:** Sample N = 10–30 recent merged agents-config PRs. For each PR's diff:
+
+- Run **V1 (current mega-QA, Codex→CC→Gemini sequential)** → record verdict + fixes + tokens.
+- Run **V2 (single best model, Opus 4.7 with extended thinking, mandatory
+  verifier-first prompt)** → record verdict + fixes + tokens.
+- Run **V3 (verifier-routed: code+tests → V1, else → V2 + grounding)** → record.
+
+Output per PR:
+- `flagged_issues_v1`, `flagged_issues_v2`, `flagged_issues_v3` (lists)
+- `fixes_applied_v{1,2,3}` (diffs)
+- `tokens_v{1,2,3}` (cost)
+- `wall_time_v{1,2,3}` (latency)
+
+**Then:** vibe-check script picks 5 best examples (where V1 and V2 most
+disagree, ranked by fix-diff size) and writes them to a file with side-by-side
+flagged issues, awaiting Brando's blind rating "which set is more useful: A,
+B, or tie." Brando's rating is then compared to a per-PR auto-rating produced
+by an extra Opus-4.7 judge — agreement between Brando and the judge is
+recorded so future rounds can be auto-scored.
+
+**Falsifies:** H2 (markdown/config: V1 ≈ V2 in usefulness) and H4 (high
+agreement = blind spot, not pass).
+
+**Cost:** ~10 PRs × 3 setups × ~50k tokens ≈ 1.5M tokens. Cheap.
+
+### Tier 2: SWE-bench Verified slice (medium, public benchmark)
+
+**What:** Run a **20-instance slice** of SWE-bench Verified end-to-end with
+each QA setup wrapping a single CC builder. Measure %resolved + tokens +
+wall-clock.
+
+- Setup A: CC builder, no QA gate (pure baseline).
+- Setup B: CC builder + V1 mega-QA gate before patch submit.
+- Setup C: CC builder + V2 single-judge gate.
+- Setup D: CC builder + V3 routed gate.
+
+**Metric:** SWE-bench Verified `resolved_rate`, plus token cost ratio and
+wall-clock ratio vs Setup A.
+
+**Falsifies:** H1 (V1 ≈ V2 on verifier-anchored code).
+
+**Cost:** ~20 instances × 4 setups, several hours each, several million
+tokens. This is the expensive one — only worth running once we've justified it
+with Tier 1.
+
+**Why a 20-instance slice and not full SWE-bench Verified:** the cost of full
+500-instance SWE-bench Verified would be tens of thousands of dollars across
+4 setups. A 20-instance stratified slice (5 easy / 10 medium / 5 hard by
+resolved-rate decile) is enough to spot a 15+ percentage-point difference at
+80% power, which is the size of effect that would actually change our
+behavior. If the slice shows a meaningful gap, we expand.
+
+### Tier 3: Bug-injection (validates H3)
+
+**What:** Take 20 already-reviewed `agents-config` PRs that previously passed
+mega-QA. Inject one of these planted issues into each:
+
+- Subtle factual error in a rule ("rerun every 5h" → "every 50h")
+- Off-by-one in a path (`scratch0` → `scratch1`)
+- Inverted boolean in a script (`if not foo` → `if foo`)
+- Broken markdown link
+- Plausible-but-wrong citation
+
+Run V1 and V2 on each modified PR. Measure:
+- Detection rate per setup
+- Detection rate of *the planted issue specifically* (not just "any flag")
+- Inter-stage agreement on the missed cases
+
+**Falsifies:** H3 (≥30% of planted issues missed by all 3 reviewers in the
+mega-QA chain).
+
+**Cost:** Cheaper than Tier 2 — same per-PR cost as Tier 1, no SWE-bench env.
+
+---
+
+## 7. Threats to validity
+
+1. **Sample is our own past PRs.** If past PRs were already filtered through
+   mega-QA, the "missed issues" rate underestimates true mega-QA misses
+   (selection effect). Mitigation: also include unmerged drafts and PRs from
+   feature branches that never made it.
+
+2. **Vibe-check rater is the same human who designed the prompts.** Brando is
+   not blind to which arm is V1 vs V2. Mitigation: the vibe-check script
+   randomizes which arm is labeled "A" vs "B" per example and stores the
+   mapping separately so the rating is at least order-blind.
+
+3. **Single-model V2 still has the same correlated-prior problem internally.**
+   Replacing 3 Anthropic-flavored verdicts with 1 Anthropic-flavored verdict
+   doesn't escape the priors; it just stops paying for the ratifications.
+   That's the *point* — we want to know whether the extra ratifications are
+   worth the cost, not whether the single verdict is unbiased.
+
+4. **SWE-bench Verified is leaky.** Recent reports of test-set contamination
+   in some training data mean the absolute resolved-rates may be inflated.
+   Mitigation: we only care about the *relative* difference between QA
+   setups, not absolute SWE-bench scores.
+
+5. **Mega-QA value may live in long-running iterative work, not single PRs.**
+   The paper studies single-question truthfulness; SlopCodeBench (sibling
+   experiment 00) studies long-horizon degradation. Single-PR benchmarks may
+   miss the compounding case where mega-QA prevents downstream rot. Tier 3
+   bug-injection only partially captures this.
+
+---
+
+## 8. Decision criteria (what we'd actually do with the result)
+
+| Outcome | Action |
+|---|---|
+| Tier 1 shows V2 ≥ V1 usefulness on markdown/config PRs (Brando's blind rating + auto-judge agree) | Switch markdown/config QA to V2; keep mega-QA only for code with tests. |
+| Tier 1 shows V1 noticeably better on prose | Keep V1 but add the deferral / cite-or-die / anti-anchoring stages from §5. |
+| Tier 2 shows Setup B/D > Setup C on SWE-bench slice | Mega-QA pays for itself on verifier-anchored code; keep it there. |
+| Tier 2 shows Setup C ≈ Setup B/D | Even on verifier-anchored code, single best-model + tests is enough; downgrade default. |
+| Tier 3 shows ≥30% planted-issue miss-rate by all 3 reviewers | Add bug-injection regression to CI; treat mega-QA PASS on non-trivial diffs as deferral signal not pass signal. |
+
+---
+
+## 9. References
+
+- Paper: "Consensus is Not Verification: Why Crowd Wisdom Strategies Fail for
+  LLM Truthfulness," arXiv:2603.06612.
+- Current QA: `~/agents-config/workflows/qa-correctness.md`.
+- Current structural QA: `~/agents-config/workflows/qa-structural.md`.
+- Sibling experiment 00 (degradation): `~/agents-config/experiments/00_refactor_qa_gate/`.
+- SWE-bench Verified: https://www.swebench.com/.

--- a/experiments/02_qa_polling_truthfulness/bench/.gitignore
+++ b/experiments/02_qa_polling_truthfulness/bench/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+swe_slice_default.txt

--- a/experiments/02_qa_polling_truthfulness/bench/README.md
+++ b/experiments/02_qa_polling_truthfulness/bench/README.md
@@ -1,0 +1,92 @@
+# Experiment 02 — Bench Scripts
+
+**TLDR:** Three runners — `run_ac_self_audit.py` (cheap, repo-specific),
+`run_swe_slice.sh` (medium, public benchmark), `run_bug_injection.py` (cheap,
+adversarial). Each emits per-PR / per-instance JSON that `vibe_check.py`
+consumes to surface 5 best/worst examples for Brando's eyeball pass.
+
+---
+
+## Quick start
+
+```bash
+# 1. Cheap repo-specific audit (Tier 1):
+python ~/agents-config/experiments/02_qa_polling_truthfulness/bench/run_ac_self_audit.py \
+    --n 10 \
+    --repo ~/agents-config \
+    --out ~/dfs/qa-polling-results/ac-self/$(date +%Y%m%d)/
+
+# 2. Vibe check on the results:
+python ~/agents-config/experiments/02_qa_polling_truthfulness/bench/vibe_check.py \
+    --in  ~/dfs/qa-polling-results/ac-self/$(date +%Y%m%d)/ \
+    --out ~/dfs/qa-polling-results/vibe/$(date +%Y%m%d)/ \
+    --k 5
+
+# 3. SWE-bench Verified slice (Tier 2, slow + expensive):
+bash ~/agents-config/experiments/02_qa_polling_truthfulness/bench/run_swe_slice.sh \
+    --n 20 \
+    --out ~/dfs/qa-polling-results/swe-slice/$(date +%Y%m%d)/
+
+# 4. Bug-injection (Tier 3, validates H3):
+python ~/agents-config/experiments/02_qa_polling_truthfulness/bench/run_bug_injection.py \
+    --n 20 \
+    --repo ~/agents-config \
+    --out ~/dfs/qa-polling-results/bug-injection/$(date +%Y%m%d)/
+```
+
+## Output schema
+
+Every per-PR / per-instance result is a JSON file with:
+
+```json
+{
+  "id": "<pr-number or swe-instance-id>",
+  "diff_summary": {
+    "files_changed": <int>,
+    "additions": <int>,
+    "deletions": <int>,
+    "languages": ["md", "py", ...],
+    "has_runnable_verifier": true | false
+  },
+  "v1": { ... per qa_v1_polling_baseline.md logging schema ... },
+  "v2": { ... per qa_v2_verifier_first.md logging schema ... },
+  "v3": { ... per qa_v3_verifier_routed.md logging schema ... },
+  "timing": {
+    "v1_seconds": <float>,
+    "v2_seconds": <float>,
+    "v3_seconds": <float>
+  },
+  "tokens": {
+    "v1_total": <int>,
+    "v2_total": <int>,
+    "v3_total": <int>
+  },
+  "agreement": {
+    "v1_v2_jaccard": <float in [0,1]>,
+    "v1_v3_jaccard": <float in [0,1]>,
+    "v2_v3_jaccard": <float in [0,1]>
+  }
+}
+```
+
+Jaccard is over `flagged_issues` lists, comparing `(file, line bucket)` pairs.
+
+## Aggregation
+
+`vibe_check.py` produces:
+
+- `summary.md` — one-page table of per-arm metrics + cost ratios + win/loss/tie.
+- `examples/example_NN.md` — top-K disagreement cases for human rating.
+- `auto_judge.json` — Opus-4.7 pre-rating per example (which arm more useful).
+- `human_rating_template.md` — pre-filled markdown for Brando to drop A/B/T.
+- `agreement.json` — Brando-vs-auto-judge agreement (filled after Brando rates).
+
+## Dependencies
+
+Python 3.10+, `pip install pyyaml` (for SWE-bench manifest parsing).
+The reviewer CLIs (`codex`, `clauded`, `gemini`) must be installed and
+authed locally — bench scripts do not bootstrap auth.
+
+If a CLI is unavailable, the run logs `"reviewer_unavailable": true` for
+that arm and continues with the others; downstream aggregation excludes
+that arm from win/loss tallies but keeps the partial result for inspection.

--- a/experiments/02_qa_polling_truthfulness/bench/README.md
+++ b/experiments/02_qa_polling_truthfulness/bench/README.md
@@ -46,7 +46,8 @@ Every per-PR / per-instance result is a JSON file with:
     "additions": <int>,
     "deletions": <int>,
     "languages": ["md", "py", ...],
-    "has_runnable_verifier": true | false
+    "has_runnable_verifier": true | false,
+    "detected_verifiers": ["pytest", "npm-test", ...]
   },
   "v1": { ... per qa_v1_polling_baseline.md logging schema ... },
   "v2": { ... per qa_v2_verifier_first.md logging schema ... },

--- a/experiments/02_qa_polling_truthfulness/bench/README.md
+++ b/experiments/02_qa_polling_truthfulness/bench/README.md
@@ -83,9 +83,10 @@ Jaccard is over `flagged_issues` lists, comparing `(file, line bucket)` pairs.
 
 ## Dependencies
 
-Python 3.10+, `pip install pyyaml` (for SWE-bench manifest parsing).
-The reviewer CLIs (`codex`, `clauded`, `gemini`) must be installed and
-authed locally — bench scripts do not bootstrap auth.
+Python 3.10+. `run_swe_slice.sh` additionally needs `pip install swebench
+datasets` (the harness + the SWE-bench-Verified dataset loader). The
+reviewer CLIs (`codex`, `clauded`, `gemini`) must be installed and authed
+locally — bench scripts do not bootstrap auth.
 
 If a CLI is unavailable, the run logs `"reviewer_unavailable": true` for
 that arm and continues with the others; downstream aggregation excludes

--- a/experiments/02_qa_polling_truthfulness/bench/run_ac_self_audit.py
+++ b/experiments/02_qa_polling_truthfulness/bench/run_ac_self_audit.py
@@ -21,8 +21,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import os
-import shlex
 import shutil
 import subprocess
 import sys
@@ -223,19 +221,23 @@ def dispatch_v2(wt: Path, prompt_path: Path) -> StageResult:
 
 
 def dispatch_v3(wt: Path, summary: dict, prompts_dir: Path) -> dict:
-    """V3: routed — markdown-only OR no-verifier source -> V2; else -> V1."""
+    """V3: routed — markdown-only OR no-verifier source -> V2; else -> V1.
+    Edge cases: empty diff (languages=[]) → all([])==True → text_only → V2
+    (the cheaper failure mode, per the V3 prompt). Missing
+    has_runnable_verifier defaults to False → also routes to V2."""
+    languages = summary.get("languages") or []
     text_only = all(
         ext in {"md", "txt", "rst", "json", "yml", "yaml", "toml", "tex", "_none"}
-        for ext in summary["languages"]
+        for ext in languages
     )
-    if text_only or not summary["has_runnable_verifier"]:
-        route, reason = "V2", "markdown_only" if text_only else "source_no_verifier"
+    has_verifier = bool(summary.get("has_runnable_verifier"))
+    if text_only or not has_verifier:
+        reason = "markdown_only" if text_only else "source_no_verifier"
         result = dispatch_v2(wt, prompts_dir / "qa_v2_verifier_first.md")
-        return {"route_decision": route, "route_reason": reason,
+        return {"route_decision": "V2", "route_reason": reason,
                 "stage": asdict(result)}
-    route, reason = "V1", "verifier_present"
     stages = dispatch_v1(wt, prompts_dir / "qa_v1_polling_baseline.md")
-    return {"route_decision": route, "route_reason": reason,
+    return {"route_decision": "V1", "route_reason": "verifier_present",
             "stages": [asdict(s) for s in stages]}
 
 
@@ -271,8 +273,10 @@ def _extract_code_block(path: Path, header_substr: str) -> str:
 
 
 def _parse_verdict(reviewer: str, rc: int, out: str, err: str, dt: float) -> StageResult:
-    """Parse the VERDICT block out of stdout. Tolerant — missing fields
-    default to ERROR/0."""
+    """Parse the VERDICT block + JSON sidecar (if present) out of stdout.
+    Tolerant — missing fields default to ERROR/0. The text VERDICT lines
+    populate scalar fields; a fenced ```json sidecar populates richer fields
+    (flagged_issues, tokens_in, tokens_out)."""
     res = StageResult(reviewer=reviewer, wall_time_s=dt,
                       raw_stdout_tail=out[-2000:])
     fields = {
@@ -294,9 +298,47 @@ def _parse_verdict(reviewer: str, rc: int, out: str, err: str, dt: float) -> Sta
                         pass
                 else:
                     setattr(res, attr, value)
+    sidecar = _extract_json_sidecar(out, err)
+    if sidecar:
+        flags = sidecar.get("flagged_issues")
+        if isinstance(flags, list):
+            res.flagged_issues = flags
+        for k in ("tokens_in", "tokens_out"):
+            v = sidecar.get(k)
+            if isinstance(v, int):
+                setattr(res, k, v)
     if rc != 0 and res.verdict == "ERROR":
         res.summary = (res.summary + f" | exit={rc}").strip(" |")
     return res
+
+
+def _extract_json_sidecar(out: str, err: str) -> dict | None:
+    """Find the first fenced ```json block in stdout/stderr that parses to a
+    dict containing 'flagged_issues' (the V1/V2 logging schema). Returns None
+    if not found or unparseable. Reviewers may emit it on stderr (per the V1
+    prompt) or inline in stdout."""
+    for stream in (err, out):
+        if not stream:
+            continue
+        idx = 0
+        while True:
+            open_fence = stream.find("```json", idx)
+            if open_fence < 0:
+                break
+            body_start = open_fence + len("```json")
+            close_fence = stream.find("```", body_start)
+            if close_fence < 0:
+                break
+            body = stream[body_start:close_fence].strip()
+            try:
+                parsed = json.loads(body)
+            except json.JSONDecodeError:
+                idx = close_fence + 3
+                continue
+            if isinstance(parsed, dict) and "flagged_issues" in parsed:
+                return parsed
+            idx = close_fence + 3
+    return None
 
 
 def jaccard(a: list, b: list, line_window: int = 10) -> float:
@@ -322,6 +364,40 @@ def jaccard(a: list, b: list, line_window: int = 10) -> float:
                 break
     union = len(a) + len(b) - matches
     return matches / max(1, union)
+
+
+def _audit_one_pr(repo: Path, pr: dict, prompts_dir: Path,
+                  out_path: Path) -> None:
+    """Run V1+V2+V3 on one PR and write the per-PR result file."""
+    sha = pr["sha"]
+    summary = diff_summary(repo, sha)
+    wt = build_worktree(repo, sha)
+    try:
+        v1_stages = dispatch_v1(wt, prompts_dir / "qa_v1_polling_baseline.md")
+        v2_result = dispatch_v2(wt, prompts_dir / "qa_v2_verifier_first.md")
+        v3_result = dispatch_v3(wt, summary, prompts_dir)
+    finally:
+        cleanup_worktree(repo, wt)
+
+    v1_flags = [f for s in v1_stages for f in s.flagged_issues]
+    v2_flags = list(v2_result.flagged_issues)
+    v3_flags = (v3_result.get("stage", {}).get("flagged_issues")
+                or [f for s in v3_result.get("stages", [])
+                    for f in s.get("flagged_issues", [])])
+    record = {
+        "id": sha,
+        "subject": pr["subject"],
+        "diff_summary": summary,
+        "v1": {"stages": [asdict(s) for s in v1_stages]},
+        "v2": asdict(v2_result),
+        "v3": v3_result,
+        "agreement": {
+            "v1_v2_jaccard": jaccard(v1_flags, v2_flags),
+            "v1_v3_jaccard": jaccard(v1_flags, v3_flags),
+            "v2_v3_jaccard": jaccard(v2_flags, v3_flags),
+        },
+    }
+    out_path.write_text(json.dumps(record, indent=2))
 
 
 def main() -> int:
@@ -350,36 +426,7 @@ def main() -> int:
         if out_path.exists():
             print(f"skip {sha[:10]} (cached)", file=sys.stderr)
             continue
-
-        summary = diff_summary(repo, sha)
-        wt = build_worktree(repo, sha)
-        try:
-            v1_stages = dispatch_v1(wt, args.prompts_dir / "qa_v1_polling_baseline.md")
-            v2_result = dispatch_v2(wt, args.prompts_dir / "qa_v2_verifier_first.md")
-            v3_result = dispatch_v3(wt, summary, args.prompts_dir)
-        finally:
-            cleanup_worktree(repo, wt)
-
-        v1_flags = [f for s in v1_stages for f in s.flagged_issues]
-        v2_flags = list(v2_result.flagged_issues)
-        v3_flags = (v3_result.get("stage", {}).get("flagged_issues")
-                    or [f for s in v3_result.get("stages", [])
-                        for f in s.get("flagged_issues", [])])
-
-        record = {
-            "id": sha,
-            "subject": pr["subject"],
-            "diff_summary": summary,
-            "v1": {"stages": [asdict(s) for s in v1_stages]},
-            "v2": asdict(v2_result),
-            "v3": v3_result,
-            "agreement": {
-                "v1_v2_jaccard": jaccard(v1_flags, v2_flags),
-                "v1_v3_jaccard": jaccard(v1_flags, v3_flags),
-                "v2_v3_jaccard": jaccard(v2_flags, v3_flags),
-            },
-        }
-        out_path.write_text(json.dumps(record, indent=2))
+        _audit_one_pr(repo, pr, args.prompts_dir, out_path)
         print(f"wrote {out_path}", file=sys.stderr)
 
     (args.out / "manifest.json").write_text(json.dumps(manifest, indent=2))

--- a/experiments/02_qa_polling_truthfulness/bench/run_ac_self_audit.py
+++ b/experiments/02_qa_polling_truthfulness/bench/run_ac_self_audit.py
@@ -1,0 +1,391 @@
+#!/usr/bin/env python3
+"""
+run_ac_self_audit.py — Replay recent agents-config PRs through V1 / V2 / V3
+QA prompts, log per-PR JSON results.
+
+TLDR: Sample N most-recent merged PRs, recreate the diff in a temp worktree,
+dispatch each QA arm against it, log results for vibe_check.py.
+
+Usage:
+    python run_ac_self_audit.py --n 10 --repo ~/agents-config --out OUT_DIR
+
+Notes:
+    - Reviewer CLIs (codex, clauded, gemini) must be on $PATH and authed.
+    - If a CLI is missing or fails, the arm is recorded as
+      reviewer_unavailable=true and skipped. Other arms still run.
+    - Results are written to OUT_DIR/pr_<num>.json (one file per PR) plus
+      OUT_DIR/manifest.json listing all PRs and their result files.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shlex
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+PROMPTS_DIR = (
+    Path(__file__).resolve().parent.parent / "prompts"
+)
+
+
+@dataclass
+class StageResult:
+    reviewer: str
+    verdict: str = "ERROR"
+    critical_issues: int = 0
+    major_issues: int = 0
+    fixes_applied: int = 0
+    structural: str = "SKIP"
+    summary: str = ""
+    flagged_issues: list = field(default_factory=list)
+    tokens_in: int = 0
+    tokens_out: int = 0
+    wall_time_s: float = 0.0
+    reviewer_unavailable: bool = False
+    raw_stdout_tail: str = ""
+
+
+def run(cmd: list[str], cwd: Path | None = None, timeout_s: int = 1800) -> tuple[int, str, str]:
+    """Run a subprocess, return (rc, stdout, stderr). Captures stderr separately."""
+    proc = subprocess.run(
+        cmd,
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        timeout=timeout_s,
+        check=False,
+    )
+    return proc.returncode, proc.stdout, proc.stderr
+
+
+def list_recent_prs(repo: Path, n: int) -> list[dict]:
+    """Approximate "recent PR" by listing merges first; fall back to recent
+    commits on main whose subject ends in `(#NN)` (squash-merged PRs);
+    final fallback: last N commits on main, period.
+
+    The diff for each item is `sha^1..sha`, so squash-merge commits work
+    too — their parent is the pre-merge main tip."""
+    candidates = [
+        ["git", "-C", str(repo), "log", "--merges", "--first-parent",
+         "main", f"-n{n}", "--pretty=format:%H%x09%s"],
+        ["git", "-C", str(repo), "log", "main", f"-n{n * 4}",
+         "--grep=(#[0-9]+)$", "-E", "--pretty=format:%H%x09%s"],
+        ["git", "-C", str(repo), "log", "main", f"-n{n}",
+         "--pretty=format:%H%x09%s"],
+    ]
+    for cmd in candidates:
+        rc, out, _ = run(cmd)
+        if rc != 0:
+            continue
+        prs = []
+        for line in out.strip().splitlines():
+            if not line:
+                continue
+            sha, subject = line.split("\t", 1)
+            prs.append({"sha": sha, "subject": subject})
+        if prs:
+            return prs[:n]
+    return []
+
+
+def diff_for_merge(repo: Path, sha: str) -> str:
+    """Return the diff that the merge commit introduced (vs its first parent)."""
+    rc, out, _ = run(
+        ["git", "-C", str(repo), "diff", f"{sha}^1..{sha}"],
+    )
+    return out if rc == 0 else ""
+
+
+def diff_summary(repo: Path, sha: str) -> dict:
+    rc, out, _ = run(
+        ["git", "-C", str(repo), "diff", "--numstat", f"{sha}^1..{sha}"],
+    )
+    files, adds, dels, langs = 0, 0, 0, set()
+    if rc == 0:
+        for line in out.splitlines():
+            parts = line.split("\t")
+            if len(parts) != 3:
+                continue
+            a, d, fn = parts
+            files += 1
+            try:
+                adds += int(a)
+                dels += int(d)
+            except ValueError:
+                pass
+            ext = Path(fn).suffix.lstrip(".") or "_none"
+            langs.add(ext)
+    return {
+        "files_changed": files,
+        "additions": adds,
+        "deletions": dels,
+        "languages": sorted(langs),
+        "has_runnable_verifier": detect_verifier(repo),
+    }
+
+
+def detect_verifier(repo: Path) -> bool:
+    """Cheap detection: is there pytest / npm test / cargo / make test runnable?"""
+    if (repo / "pytest.ini").exists() or (repo / "pyproject.toml").exists():
+        rc, _, _ = run(["python", "-c", "import pytest"], timeout_s=10)
+        if rc == 0:
+            return True
+    if (repo / "package.json").exists():
+        try:
+            pkg = json.loads((repo / "package.json").read_text())
+            if (pkg.get("scripts") or {}).get("test"):
+                return True
+        except Exception:
+            pass
+    if (repo / "Cargo.toml").exists():
+        return True
+    mk = repo / "Makefile"
+    if mk.exists() and "test:" in mk.read_text():
+        return True
+    return False
+
+
+def build_worktree(repo: Path, sha: str) -> Path:
+    """Create a throwaway worktree at the merge commit so reviewers see the
+    state as it landed. Caller must delete when done."""
+    wt = Path(tempfile.mkdtemp(prefix="qapoll_"))
+    rc, _, err = run(
+        ["git", "-C", str(repo), "worktree", "add", "--detach", str(wt), sha],
+    )
+    if rc != 0:
+        shutil.rmtree(wt, ignore_errors=True)
+        raise RuntimeError(f"worktree add failed: {err}")
+    return wt
+
+
+def cleanup_worktree(repo: Path, wt: Path) -> None:
+    run(["git", "-C", str(repo), "worktree", "remove", "--force", str(wt)])
+    shutil.rmtree(wt, ignore_errors=True)
+
+
+def cli_available(name: str) -> bool:
+    return shutil.which(name) is not None
+
+
+def dispatch_v1(wt: Path, prompt_path: Path) -> list[StageResult]:
+    """V1 mega-QA: Codex -> CC -> Gemini sequential."""
+    chain = [
+        ("codex", ["codex", "exec", "--full-auto", _read_v1_stage_prompt(prompt_path)]),
+        ("cc",    ["clauded", "-p", _read_v1_stage_prompt(prompt_path)]),
+        ("gemini",["gemini", "-p", _read_v1_stage_prompt(prompt_path)]),
+    ]
+    results = []
+    for reviewer, cmd in chain:
+        if not cli_available(cmd[0]):
+            results.append(StageResult(reviewer=reviewer, reviewer_unavailable=True,
+                                       summary="CLI not on PATH"))
+            continue
+        t0 = time.monotonic()
+        try:
+            rc, out, err = run(cmd, cwd=wt, timeout_s=1800)
+        except subprocess.TimeoutExpired:
+            results.append(StageResult(reviewer=reviewer, verdict="ERROR",
+                                       summary="timeout", wall_time_s=1800))
+            continue
+        dt = time.monotonic() - t0
+        results.append(_parse_verdict(reviewer, rc, out, err, dt))
+    return results
+
+
+def dispatch_v2(wt: Path, prompt_path: Path) -> StageResult:
+    """V2: single best-model + verifier-first."""
+    prompt = _read_v2_prompt(prompt_path)
+    candidates = [
+        ("cc",     ["clauded", "-p", prompt]),
+        ("codex",  ["codex", "exec", "--full-auto", prompt]),
+        ("gemini", ["gemini", "-p", prompt]),
+    ]
+    for reviewer, cmd in candidates:
+        if cli_available(cmd[0]):
+            t0 = time.monotonic()
+            try:
+                rc, out, err = run(cmd, cwd=wt, timeout_s=2400)
+            except subprocess.TimeoutExpired:
+                return StageResult(reviewer=reviewer, verdict="ERROR",
+                                   summary="timeout", wall_time_s=2400)
+            return _parse_verdict(reviewer, rc, out, err,
+                                  time.monotonic() - t0)
+    return StageResult(reviewer="none", reviewer_unavailable=True,
+                       summary="no reviewer CLI available")
+
+
+def dispatch_v3(wt: Path, summary: dict, prompts_dir: Path) -> dict:
+    """V3: routed — markdown-only OR no-verifier source -> V2; else -> V1."""
+    text_only = all(
+        ext in {"md", "txt", "rst", "json", "yml", "yaml", "toml", "tex", "_none"}
+        for ext in summary["languages"]
+    )
+    if text_only or not summary["has_runnable_verifier"]:
+        route, reason = "V2", "markdown_only" if text_only else "source_no_verifier"
+        result = dispatch_v2(wt, prompts_dir / "qa_v2_verifier_first.md")
+        return {"route_decision": route, "route_reason": reason,
+                "stage": asdict(result)}
+    route, reason = "V1", "verifier_present"
+    stages = dispatch_v1(wt, prompts_dir / "qa_v1_polling_baseline.md")
+    return {"route_decision": route, "route_reason": reason,
+            "stages": [asdict(s) for s in stages]}
+
+
+_V1_RE_BLOCK = "Per-stage prompt"
+_V2_RE_BLOCK = "Per-run prompt"
+
+
+def _read_v1_stage_prompt(path: Path) -> str:
+    """Pull the verbatim block from prompts/qa_v1_polling_baseline.md."""
+    return _extract_code_block(path, "Per-stage prompt")
+
+
+def _read_v2_prompt(path: Path) -> str:
+    return _extract_code_block(path, "Per-run prompt")
+
+
+def _extract_code_block(path: Path, header_substr: str) -> str:
+    text = path.read_text()
+    parts = text.split(header_substr, 1)
+    if len(parts) < 2:
+        raise RuntimeError(f"header '{header_substr}' not found in {path}")
+    after = parts[1]
+    fence_open = after.find("```")
+    if fence_open < 0:
+        raise RuntimeError(f"no code fence after '{header_substr}' in {path}")
+    fence_close = after.find("```", fence_open + 3)
+    if fence_close < 0:
+        raise RuntimeError(f"unterminated code fence after '{header_substr}' in {path}")
+    block = after[fence_open + 3:fence_close]
+    if "\n" in block:
+        block = block.split("\n", 1)[1]
+    return block.strip()
+
+
+def _parse_verdict(reviewer: str, rc: int, out: str, err: str, dt: float) -> StageResult:
+    """Parse the VERDICT block out of stdout. Tolerant — missing fields
+    default to ERROR/0."""
+    res = StageResult(reviewer=reviewer, wall_time_s=dt,
+                      raw_stdout_tail=out[-2000:])
+    fields = {
+        "VERDICT": "verdict",
+        "CRITICAL_ISSUES": "critical_issues",
+        "MAJOR_ISSUES": "major_issues",
+        "FIXES_APPLIED": "fixes_applied",
+        "STRUCTURAL": "structural",
+        "SUMMARY": "summary",
+    }
+    for line in out.splitlines():
+        for key, attr in fields.items():
+            if line.startswith(f"{key}:"):
+                value = line.split(":", 1)[1].strip()
+                if attr in {"critical_issues", "major_issues", "fixes_applied"}:
+                    try:
+                        setattr(res, attr, int(value.split()[0]))
+                    except (ValueError, IndexError):
+                        pass
+                else:
+                    setattr(res, attr, value)
+    if rc != 0 and res.verdict == "ERROR":
+        res.summary = (res.summary + f" | exit={rc}").strip(" |")
+    return res
+
+
+def jaccard(a: list, b: list, line_window: int = 10) -> float:
+    """Tolerant Jaccard: a flag in A matches a flag in B iff same file and
+    |line_a - line_b| <= line_window (default 10). Avoids the
+    fixed-bucket-boundary problem where lines 47 and 51 map to different
+    buckets despite being adjacent."""
+    if not a and not b:
+        return 1.0
+    matched_b = set()
+    matches = 0
+    for fa in a:
+        for j, fb in enumerate(b):
+            if j in matched_b:
+                continue
+            if fa.get("file") != fb.get("file"):
+                continue
+            la = fa.get("line") or 0
+            lb = fb.get("line") or 0
+            if abs(la - lb) <= line_window:
+                matched_b.add(j)
+                matches += 1
+                break
+    union = len(a) + len(b) - matches
+    return matches / max(1, union)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--n", type=int, default=10, help="number of recent PRs")
+    ap.add_argument("--repo", type=Path,
+                    default=Path.home() / "agents-config")
+    ap.add_argument("--out", type=Path, required=True)
+    ap.add_argument("--prompts-dir", type=Path, default=PROMPTS_DIR)
+    args = ap.parse_args()
+
+    args.out.mkdir(parents=True, exist_ok=True)
+    repo = args.repo.expanduser().resolve()
+
+    prs = list_recent_prs(repo, args.n)
+    if not prs:
+        print("no PRs found", file=sys.stderr)
+        return 1
+
+    manifest = []
+    for pr in prs:
+        sha = pr["sha"]
+        out_path = args.out / f"pr_{sha[:10]}.json"
+        manifest.append({"sha": sha, "subject": pr["subject"],
+                         "result_file": out_path.name})
+        if out_path.exists():
+            print(f"skip {sha[:10]} (cached)", file=sys.stderr)
+            continue
+
+        summary = diff_summary(repo, sha)
+        wt = build_worktree(repo, sha)
+        try:
+            v1_stages = dispatch_v1(wt, args.prompts_dir / "qa_v1_polling_baseline.md")
+            v2_result = dispatch_v2(wt, args.prompts_dir / "qa_v2_verifier_first.md")
+            v3_result = dispatch_v3(wt, summary, args.prompts_dir)
+        finally:
+            cleanup_worktree(repo, wt)
+
+        v1_flags = [f for s in v1_stages for f in s.flagged_issues]
+        v2_flags = list(v2_result.flagged_issues)
+        v3_flags = (v3_result.get("stage", {}).get("flagged_issues")
+                    or [f for s in v3_result.get("stages", [])
+                        for f in s.get("flagged_issues", [])])
+
+        record = {
+            "id": sha,
+            "subject": pr["subject"],
+            "diff_summary": summary,
+            "v1": {"stages": [asdict(s) for s in v1_stages]},
+            "v2": asdict(v2_result),
+            "v3": v3_result,
+            "agreement": {
+                "v1_v2_jaccard": jaccard(v1_flags, v2_flags),
+                "v1_v3_jaccard": jaccard(v1_flags, v3_flags),
+                "v2_v3_jaccard": jaccard(v2_flags, v3_flags),
+            },
+        }
+        out_path.write_text(json.dumps(record, indent=2))
+        print(f"wrote {out_path}", file=sys.stderr)
+
+    (args.out / "manifest.json").write_text(json.dumps(manifest, indent=2))
+    print(f"manifest at {args.out / 'manifest.json'}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/experiments/02_qa_polling_truthfulness/bench/run_ac_self_audit.py
+++ b/experiments/02_qa_polling_truthfulness/bench/run_ac_self_audit.py
@@ -49,6 +49,12 @@ class StageResult:
     wall_time_s: float = 0.0
     reviewer_unavailable: bool = False
     raw_stdout_tail: str = ""
+    # V2-only fields. V1 reviewers won't emit these — left at default. Per
+    # qa_v2_verifier_first.md "Logging requirements", verifier_ran is the key
+    # slicing variable: rows where it's "none" / [] are where the paper's
+    # argument applies most cleanly (no external grounding).
+    verifier_ran: list | str = field(default_factory=list)
+    consensus_warning: bool = False
 
 
 def run(cmd: list[str], cwd: Path | None = None, timeout_s: int = 1800) -> tuple[int, str, str]:
@@ -298,6 +304,16 @@ def _parse_verdict(reviewer: str, rc: int, out: str, err: str, dt: float) -> Sta
                         pass
                 else:
                     setattr(res, attr, value)
+        # V2-only verdict-block lines. The V2 prompt requires these in the
+        # final block (qa_v2_verifier_first.md lines 94-95). Stored verbatim
+        # as strings here; the JSON sidecar (if present) overrides with
+        # structured forms (list / bool).
+        if line.startswith("VERIFIER_RAN:"):
+            raw = line.split(":", 1)[1].strip()
+            res.verifier_ran = raw  # string form; sidecar may overwrite
+        elif line.startswith("CONSENSUS_WARNING:"):
+            v = line.split(":", 1)[1].strip().lower()
+            res.consensus_warning = v in {"yes", "true", "y"}
     sidecar = _extract_json_sidecar(out, err)
     if sidecar:
         flags = sidecar.get("flagged_issues")
@@ -307,6 +323,13 @@ def _parse_verdict(reviewer: str, rc: int, out: str, err: str, dt: float) -> Sta
             v = sidecar.get(k)
             if isinstance(v, int):
                 setattr(res, k, v)
+        # V2 sidecar may carry structured verifier_ran / consensus_warning.
+        vr = sidecar.get("verifier_ran")
+        if isinstance(vr, (list, str)):
+            res.verifier_ran = vr
+        cw = sidecar.get("consensus_warning")
+        if isinstance(cw, bool):
+            res.consensus_warning = cw
     if rc != 0 and res.verdict == "ERROR":
         res.summary = (res.summary + f" | exit={rc}").strip(" |")
     return res

--- a/experiments/02_qa_polling_truthfulness/bench/run_ac_self_audit.py
+++ b/experiments/02_qa_polling_truthfulness/bench/run_ac_self_audit.py
@@ -52,9 +52,11 @@ class StageResult:
     # V2-only fields. V1 reviewers won't emit these — left at default. Per
     # qa_v2_verifier_first.md "Logging requirements", verifier_ran is the key
     # slicing variable: rows where it's "none" / [] are where the paper's
-    # argument applies most cleanly (no external grounding).
+    # argument applies most cleanly (no external grounding). citations is the
+    # cite-or-defer evidence list.
     verifier_ran: list | str = field(default_factory=list)
     consensus_warning: bool = False
+    citations: list = field(default_factory=list)
 
 
 def run(cmd: list[str], cwd: Path | None = None, timeout_s: int = 1800) -> tuple[int, str, str]:
@@ -127,34 +129,44 @@ def diff_summary(repo: Path, sha: str) -> dict:
                 pass
             ext = Path(fn).suffix.lstrip(".") or "_none"
             langs.add(ext)
+    detected = detect_verifier_names(repo)
     return {
         "files_changed": files,
         "additions": adds,
         "deletions": dels,
         "languages": sorted(langs),
-        "has_runnable_verifier": detect_verifier(repo),
+        "has_runnable_verifier": bool(detected),
+        "detected_verifiers": detected,
     }
 
 
 def detect_verifier(repo: Path) -> bool:
     """Cheap detection: is there pytest / npm test / cargo / make test runnable?"""
+    return bool(detect_verifier_names(repo))
+
+
+def detect_verifier_names(repo: Path) -> list[str]:
+    """Same checks as detect_verifier, but returns the list of detected
+    verifier names (e.g. ["pytest", "npm-test"]) so V3 logging can record
+    which ones were available. Empty list = none detected."""
+    found: list[str] = []
     if (repo / "pytest.ini").exists() or (repo / "pyproject.toml").exists():
         rc, _, _ = run(["python", "-c", "import pytest"], timeout_s=10)
         if rc == 0:
-            return True
+            found.append("pytest")
     if (repo / "package.json").exists():
         try:
             pkg = json.loads((repo / "package.json").read_text())
             if (pkg.get("scripts") or {}).get("test"):
-                return True
+                found.append("npm-test")
         except Exception:
             pass
     if (repo / "Cargo.toml").exists():
-        return True
+        found.append("cargo-test")
     mk = repo / "Makefile"
     if mk.exists() and "test:" in mk.read_text():
-        return True
-    return False
+        found.append("make-test")
+    return found
 
 
 def build_worktree(repo: Path, sha: str) -> Path:
@@ -173,6 +185,13 @@ def build_worktree(repo: Path, sha: str) -> Path:
 def cleanup_worktree(repo: Path, wt: Path) -> None:
     run(["git", "-C", str(repo), "worktree", "remove", "--force", str(wt)])
     shutil.rmtree(wt, ignore_errors=True)
+
+
+def prune_stale_worktrees(repo: Path) -> None:
+    """Remove worktree metadata for /tmp/qapoll_* that disappeared (script
+    killed mid-run). Safe to call on every startup; no-ops when nothing
+    stale. Without this, repeated crashes leak `git worktree list` entries."""
+    run(["git", "-C", str(repo), "worktree", "prune"], timeout_s=30)
 
 
 def cli_available(name: str) -> bool:
@@ -230,20 +249,24 @@ def dispatch_v3(wt: Path, summary: dict, prompts_dir: Path) -> dict:
     """V3: routed — markdown-only OR no-verifier source -> V2; else -> V1.
     Edge cases: empty diff (languages=[]) → all([])==True → text_only → V2
     (the cheaper failure mode, per the V3 prompt). Missing
-    has_runnable_verifier defaults to False → also routes to V2."""
+    has_runnable_verifier defaults to False → also routes to V2.
+    Output shape matches qa_v3_verifier_routed.md "Logging requirements":
+    route_decision / route_reason / detected_verifiers + V1- or V2-shaped
+    sub-payload."""
     languages = summary.get("languages") or []
     text_only = all(
         ext in {"md", "txt", "rst", "json", "yml", "yaml", "toml", "tex", "_none"}
         for ext in languages
     )
-    has_verifier = bool(summary.get("has_runnable_verifier"))
-    if text_only or not has_verifier:
+    detected = list(summary.get("detected_verifiers") or [])
+    if text_only or not detected:
         reason = "markdown_only" if text_only else "source_no_verifier"
         result = dispatch_v2(wt, prompts_dir / "qa_v2_verifier_first.md")
         return {"route_decision": "V2", "route_reason": reason,
-                "stage": asdict(result)}
+                "detected_verifiers": detected, "stage": asdict(result)}
     stages = dispatch_v1(wt, prompts_dir / "qa_v1_polling_baseline.md")
     return {"route_decision": "V1", "route_reason": "verifier_present",
+            "detected_verifiers": detected,
             "stages": [asdict(s) for s in stages]}
 
 
@@ -278,58 +301,72 @@ def _extract_code_block(path: Path, header_substr: str) -> str:
     return block.strip()
 
 
+_TEXT_FIELDS = {
+    "VERDICT": "verdict",
+    "CRITICAL_ISSUES": "critical_issues",
+    "MAJOR_ISSUES": "major_issues",
+    "FIXES_APPLIED": "fixes_applied",
+    "STRUCTURAL": "structural",
+    "SUMMARY": "summary",
+}
+_INT_FIELDS = {"critical_issues", "major_issues", "fixes_applied"}
+
+
+def _apply_text_line(res: StageResult, line: str) -> None:
+    """Match one VERDICT-block line against the known fields and set on res."""
+    for key, attr in _TEXT_FIELDS.items():
+        if not line.startswith(f"{key}:"):
+            continue
+        value = line.split(":", 1)[1].strip()
+        if attr not in _INT_FIELDS:
+            setattr(res, attr, value)
+            return
+        try:
+            setattr(res, attr, int(value.split()[0]))
+        except (ValueError, IndexError):
+            pass
+        return
+    if line.startswith("VERIFIER_RAN:"):
+        res.verifier_ran = line.split(":", 1)[1].strip()
+    elif line.startswith("CONSENSUS_WARNING:"):
+        v = line.split(":", 1)[1].strip().lower()
+        res.consensus_warning = v in {"yes", "true", "y"}
+
+
+def _apply_sidecar(res: StageResult, sidecar: dict) -> None:
+    """Overlay structured fields from a JSON sidecar onto res. The sidecar
+    overrides the text VERDICT lines for the V2 fields (verifier_ran,
+    consensus_warning, citations) so structured forms win when present."""
+    flags = sidecar.get("flagged_issues")
+    if isinstance(flags, list):
+        res.flagged_issues = flags
+    for k in ("tokens_in", "tokens_out"):
+        v = sidecar.get(k)
+        if isinstance(v, int):
+            setattr(res, k, v)
+    vr = sidecar.get("verifier_ran")
+    if isinstance(vr, (list, str)):
+        res.verifier_ran = vr
+    cw = sidecar.get("consensus_warning")
+    if isinstance(cw, bool):
+        res.consensus_warning = cw
+    cites = sidecar.get("citations")
+    if isinstance(cites, list):
+        res.citations = cites
+
+
 def _parse_verdict(reviewer: str, rc: int, out: str, err: str, dt: float) -> StageResult:
     """Parse the VERDICT block + JSON sidecar (if present) out of stdout.
     Tolerant — missing fields default to ERROR/0. The text VERDICT lines
     populate scalar fields; a fenced ```json sidecar populates richer fields
-    (flagged_issues, tokens_in, tokens_out)."""
+    (flagged_issues, tokens_in, tokens_out, V2's verifier_ran / citations)."""
     res = StageResult(reviewer=reviewer, wall_time_s=dt,
                       raw_stdout_tail=out[-2000:])
-    fields = {
-        "VERDICT": "verdict",
-        "CRITICAL_ISSUES": "critical_issues",
-        "MAJOR_ISSUES": "major_issues",
-        "FIXES_APPLIED": "fixes_applied",
-        "STRUCTURAL": "structural",
-        "SUMMARY": "summary",
-    }
     for line in out.splitlines():
-        for key, attr in fields.items():
-            if line.startswith(f"{key}:"):
-                value = line.split(":", 1)[1].strip()
-                if attr in {"critical_issues", "major_issues", "fixes_applied"}:
-                    try:
-                        setattr(res, attr, int(value.split()[0]))
-                    except (ValueError, IndexError):
-                        pass
-                else:
-                    setattr(res, attr, value)
-        # V2-only verdict-block lines. The V2 prompt requires these in the
-        # final block (qa_v2_verifier_first.md lines 94-95). Stored verbatim
-        # as strings here; the JSON sidecar (if present) overrides with
-        # structured forms (list / bool).
-        if line.startswith("VERIFIER_RAN:"):
-            raw = line.split(":", 1)[1].strip()
-            res.verifier_ran = raw  # string form; sidecar may overwrite
-        elif line.startswith("CONSENSUS_WARNING:"):
-            v = line.split(":", 1)[1].strip().lower()
-            res.consensus_warning = v in {"yes", "true", "y"}
+        _apply_text_line(res, line)
     sidecar = _extract_json_sidecar(out, err)
     if sidecar:
-        flags = sidecar.get("flagged_issues")
-        if isinstance(flags, list):
-            res.flagged_issues = flags
-        for k in ("tokens_in", "tokens_out"):
-            v = sidecar.get(k)
-            if isinstance(v, int):
-                setattr(res, k, v)
-        # V2 sidecar may carry structured verifier_ran / consensus_warning.
-        vr = sidecar.get("verifier_ran")
-        if isinstance(vr, (list, str)):
-            res.verifier_ran = vr
-        cw = sidecar.get("consensus_warning")
-        if isinstance(cw, bool):
-            res.consensus_warning = cw
+        _apply_sidecar(res, sidecar)
     if rc != 0 and res.verdict == "ERROR":
         res.summary = (res.summary + f" | exit={rc}").strip(" |")
     return res
@@ -434,6 +471,7 @@ def main() -> int:
 
     args.out.mkdir(parents=True, exist_ok=True)
     repo = args.repo.expanduser().resolve()
+    prune_stale_worktrees(repo)
 
     prs = list_recent_prs(repo, args.n)
     if not prs:

--- a/experiments/02_qa_polling_truthfulness/bench/run_bug_injection.py
+++ b/experiments/02_qa_polling_truthfulness/bench/run_bug_injection.py
@@ -18,19 +18,15 @@ import argparse
 import json
 import random
 import re
-import shutil
-import subprocess
 import sys
-import tempfile
-import time
 from dataclasses import asdict
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from run_ac_self_audit import (  # noqa: E402
-    StageResult, build_worktree, cleanup_worktree,
-    detect_verifier, dispatch_v1, dispatch_v2,
-    list_recent_prs, run,
+    build_worktree, cleanup_worktree,
+    dispatch_v1, dispatch_v2,
+    list_recent_prs,
 )
 
 PROMPTS_DIR = Path(__file__).resolve().parent.parent / "prompts"
@@ -115,12 +111,79 @@ def plant_in_worktree(wt: Path, rng: random.Random) -> dict | None:
 
 
 def detect_plant_in_flags(plant: dict, flags: list) -> bool:
-    """A flag 'detects' the plant if it cites the same file (line-agnostic)."""
-    plant_file = plant["file"]
+    """A flag 'detects' the plant if it cites the same file (line-agnostic).
+    Match is on path equality after normalization OR on whole-segment suffix
+    (e.g., flag 'a/b/foo.py' matches plant 'b/foo.py' but NOT 'oo.py' and
+    NOT plant 'foo.py' alone — the boundary char must be '/' or start)."""
+    plant_path = plant["file"].lstrip("./")
     for flag in flags:
-        if flag.get("file", "").endswith(plant_file):
+        flag_path = (flag.get("file") or "").lstrip("./")
+        if not flag_path:
+            continue
+        if flag_path == plant_path:
+            return True
+        # Whole-segment suffix: flag must end with "/<plant_path>" so we don't
+        # match e.g. "foo.py" inside "barfoo.py".
+        if flag_path.endswith("/" + plant_path):
+            return True
+        # And the reverse: plant might be the longer normalized path while the
+        # reviewer cited just the basename or sub-path.
+        if plant_path.endswith("/" + flag_path):
             return True
     return False
+
+
+def _process_pr(repo: Path, pr: dict, rng: random.Random,
+                out_dir: Path) -> dict | None:
+    """Run one PR through plant + V1 + V2; return record dict or None if no
+    injector fit. Side-effect: writes plant_<sha>.json to out_dir."""
+    sha = pr["sha"]
+    wt = build_worktree(repo, sha)
+    try:
+        plant = plant_in_worktree(wt, rng)
+        if plant is None:
+            return None
+        v1_stages = dispatch_v1(wt, PROMPTS_DIR / "qa_v1_polling_baseline.md")
+        v2_result = dispatch_v2(wt, PROMPTS_DIR / "qa_v2_verifier_first.md")
+    finally:
+        cleanup_worktree(repo, wt)
+
+    v1_flags_per_stage = [list(s.flagged_issues) for s in v1_stages]
+    v1_per_stage_detected = [detect_plant_in_flags(plant, ff)
+                             for ff in v1_flags_per_stage]
+    record = {
+        "id": sha,
+        "subject": pr["subject"],
+        "plant": plant,
+        "v1_chain_detected": any(v1_per_stage_detected),
+        "v1_per_stage_detected": v1_per_stage_detected,
+        "v2_detected": detect_plant_in_flags(plant, v2_result.flagged_issues),
+        "v1": {"stages": [asdict(s) for s in v1_stages]},
+        "v2": asdict(v2_result),
+    }
+    (out_dir / f"plant_{sha[:10]}.json").write_text(json.dumps(record, indent=2))
+    return record
+
+
+def _write_summary(rows: list[dict], out_dir: Path) -> None:
+    """Compute aggregate detection rates + write summary.md + print TLDR."""
+    n = len(rows)
+    v1_chain_rate = sum(r["v1_chain_detected"] for r in rows) / n
+    v2_rate = sum(r["v2_detected"] for r in rows) / n
+    all_miss = sum(1 for r in rows
+                   if not any(r["v1_per_stage_detected"])
+                   and not r["v2_detected"]) / n
+    h3_status = "**FALSIFIED**" if all_miss < 0.30 else "**SUPPORTED**"
+    summary_md = (
+        f"# Bug-injection results\n\n"
+        f"**TLDR:** N={n} PRs each given one planted issue. V1 chain "
+        f"detection rate: {v1_chain_rate:.0%}. V2 detection rate: "
+        f"{v2_rate:.0%}. Both arms missed: {all_miss:.0%}.\n\n"
+        f'H3 ("correlated blind spots: ≥30% of plants missed by all 3 '
+        f'reviewers") is {h3_status} by these data.\n'
+    )
+    (out_dir / "summary.md").write_text(summary_md)
+    print(summary_md)
 
 
 def main() -> int:
@@ -136,69 +199,24 @@ def main() -> int:
     repo = args.repo.expanduser().resolve()
     rng = random.Random(args.seed)
 
-    prs = list_recent_prs(repo, args.n * 2)  # over-sample; some may not have plantable text
-    plants_done = 0
+    prs = list_recent_prs(repo, args.n * 2)  # over-sample; some lack plantable text
     summary_rows = []
-
     for pr in prs:
-        if plants_done >= args.n:
+        if len(summary_rows) >= args.n:
             break
-        sha = pr["sha"]
-        wt = build_worktree(repo, sha)
-        try:
-            plant = plant_in_worktree(wt, rng)
-            if plant is None:
-                continue
-            v1_stages = dispatch_v1(wt, PROMPTS_DIR / "qa_v1_polling_baseline.md")
-            v2_result = dispatch_v2(wt, PROMPTS_DIR / "qa_v2_verifier_first.md")
-        finally:
-            cleanup_worktree(repo, wt)
-
-        v1_flags_per_stage = [list(s.flagged_issues) for s in v1_stages]
-        v1_chain_detected = any(detect_plant_in_flags(plant, ff)
-                                for ff in v1_flags_per_stage)
-        v1_per_stage_detected = [detect_plant_in_flags(plant, ff)
-                                 for ff in v1_flags_per_stage]
-        v2_detected = detect_plant_in_flags(plant, v2_result.flagged_issues)
-
-        record = {
-            "id": sha,
-            "subject": pr["subject"],
-            "plant": plant,
-            "v1_chain_detected": v1_chain_detected,
-            "v1_per_stage_detected": v1_per_stage_detected,
-            "v2_detected": v2_detected,
-            "v1": {"stages": [asdict(s) for s in v1_stages]},
-            "v2": asdict(v2_result),
-        }
-        out_path = args.out / f"plant_{sha[:10]}.json"
-        out_path.write_text(json.dumps(record, indent=2))
+        record = _process_pr(repo, pr, rng, args.out)
+        if record is None:
+            continue
         summary_rows.append(record)
-        plants_done += 1
-        print(f"[{plants_done}/{args.n}] {sha[:10]}  v1_chain={v1_chain_detected}  v2={v2_detected}",
-              file=sys.stderr)
+        sha = pr["sha"]
+        print(f"[{len(summary_rows)}/{args.n}] {sha[:10]}  "
+              f"v1_chain={record['v1_chain_detected']}  "
+              f"v2={record['v2_detected']}", file=sys.stderr)
 
     if not summary_rows:
         print("no PRs accepted a plant; try --n larger", file=sys.stderr)
         return 1
-
-    n = len(summary_rows)
-    v1_chain_rate = sum(r["v1_chain_detected"] for r in summary_rows) / n
-    v2_rate = sum(r["v2_detected"] for r in summary_rows) / n
-    all_miss = sum(1 for r in summary_rows
-                   if not any(r["v1_per_stage_detected"]) and not r["v2_detected"]) / n
-
-    summary_md = f"""# Bug-injection results
-
-**TLDR:** N={n} PRs each given one planted issue. V1 chain detection rate:
-{v1_chain_rate:.0%}. V2 detection rate: {v2_rate:.0%}. Both arms missed:
-{all_miss:.0%}.
-
-H3 ("correlated blind spots: ≥30% of plants missed by all 3 reviewers")
-is {'**FALSIFIED**' if all_miss < 0.30 else '**SUPPORTED**'} by these data.
-"""
-    (args.out / "summary.md").write_text(summary_md)
-    print(summary_md)
+    _write_summary(summary_rows, args.out)
     return 0
 
 

--- a/experiments/02_qa_polling_truthfulness/bench/run_bug_injection.py
+++ b/experiments/02_qa_polling_truthfulness/bench/run_bug_injection.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""
+run_bug_injection.py — Validate H3 (correlated blind spots): inject one
+planted issue into each of N already-merged PRs, then run V1 and V2 against
+the modified diff. Measure detection rate per arm and how often all 3 V1
+stages miss the same case.
+
+TLDR: Take real PR + plant a known bug + see if QA arms catch it. The
+miss-rate of V1's full chain is the H3 falsifier.
+
+Usage:
+    python run_bug_injection.py --n 20 --repo ~/agents-config --out OUT_DIR
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from dataclasses import asdict
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from run_ac_self_audit import (  # noqa: E402
+    StageResult, build_worktree, cleanup_worktree,
+    detect_verifier, dispatch_v1, dispatch_v2,
+    list_recent_prs, run,
+)
+
+PROMPTS_DIR = Path(__file__).resolve().parent.parent / "prompts"
+
+
+# Each injector returns (modified_text, plant_description) or None if N/A.
+def inject_path_typo(text: str) -> tuple[str, str] | None:
+    if "scratch0" in text:
+        return text.replace("scratch0", "scratch1", 1), \
+               "path typo: scratch0 -> scratch1 (would break DFS resolution)"
+    return None
+
+
+def inject_inverted_bool(text: str) -> tuple[str, str] | None:
+    m = re.search(r"\bif\s+not\s+(\w+)\s*:", text)
+    if m:
+        modified = text[:m.start()] + f"if {m.group(1)}:" + text[m.end():]
+        return modified, f"inverted boolean: 'if not {m.group(1)}:' -> 'if {m.group(1)}:'"
+    return None
+
+
+def inject_off_by_factor(text: str) -> tuple[str, str] | None:
+    m = re.search(r"every\s+(\d+)\s*h", text)
+    if m:
+        bad = str(int(m.group(1)) * 10)
+        modified = text[:m.start()] + f"every {bad}h" + text[m.end():]
+        return modified, f"off-by-factor: '{m.group(0)}' -> 'every {bad}h'"
+    return None
+
+
+def inject_bad_link(text: str) -> tuple[str, str] | None:
+    m = re.search(r"\]\((https?://[^\)]+)\)", text)
+    if m:
+        bad = m.group(1)[:-3] + "_BROKEN"
+        modified = text.replace(m.group(0), f"]({bad})", 1)
+        return modified, f"broken link: {m.group(1)} -> {bad}"
+    return None
+
+
+def inject_wrong_citation(text: str) -> tuple[str, str] | None:
+    m = re.search(r"arXiv:(\d{4}\.\d{4,5})", text)
+    if m:
+        bad = "9999.99999"
+        modified = text.replace(m.group(0), f"arXiv:{bad}", 1)
+        return modified, f"plausible-but-fake citation: {m.group(0)} -> arXiv:{bad}"
+    return None
+
+
+INJECTORS = [
+    inject_path_typo,
+    inject_inverted_bool,
+    inject_off_by_factor,
+    inject_bad_link,
+    inject_wrong_citation,
+]
+
+
+def plant_in_worktree(wt: Path, rng: random.Random) -> dict | None:
+    """Pick a tracked text file in wt and try injectors in random order until one fits."""
+    files = []
+    for ext in ("*.md", "*.py", "*.sh", "*.txt"):
+        files.extend(wt.rglob(ext))
+    rng.shuffle(files)
+    injs = list(INJECTORS)
+    rng.shuffle(injs)
+
+    for f in files:
+        if any(part.startswith(".") for part in f.parts):
+            continue
+        try:
+            txt = f.read_text()
+        except UnicodeDecodeError:
+            continue
+        for inj in injs:
+            res = inj(txt)
+            if res is None:
+                continue
+            new_txt, desc = res
+            f.write_text(new_txt)
+            return {"file": str(f.relative_to(wt)), "description": desc}
+    return None
+
+
+def detect_plant_in_flags(plant: dict, flags: list) -> bool:
+    """A flag 'detects' the plant if it cites the same file (line-agnostic)."""
+    plant_file = plant["file"]
+    for flag in flags:
+        if flag.get("file", "").endswith(plant_file):
+            return True
+    return False
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--n", type=int, default=20)
+    ap.add_argument("--repo", type=Path,
+                    default=Path.home() / "agents-config")
+    ap.add_argument("--out", type=Path, required=True)
+    ap.add_argument("--seed", type=int, default=42)
+    args = ap.parse_args()
+
+    args.out.mkdir(parents=True, exist_ok=True)
+    repo = args.repo.expanduser().resolve()
+    rng = random.Random(args.seed)
+
+    prs = list_recent_prs(repo, args.n * 2)  # over-sample; some may not have plantable text
+    plants_done = 0
+    summary_rows = []
+
+    for pr in prs:
+        if plants_done >= args.n:
+            break
+        sha = pr["sha"]
+        wt = build_worktree(repo, sha)
+        try:
+            plant = plant_in_worktree(wt, rng)
+            if plant is None:
+                continue
+            v1_stages = dispatch_v1(wt, PROMPTS_DIR / "qa_v1_polling_baseline.md")
+            v2_result = dispatch_v2(wt, PROMPTS_DIR / "qa_v2_verifier_first.md")
+        finally:
+            cleanup_worktree(repo, wt)
+
+        v1_flags_per_stage = [list(s.flagged_issues) for s in v1_stages]
+        v1_chain_detected = any(detect_plant_in_flags(plant, ff)
+                                for ff in v1_flags_per_stage)
+        v1_per_stage_detected = [detect_plant_in_flags(plant, ff)
+                                 for ff in v1_flags_per_stage]
+        v2_detected = detect_plant_in_flags(plant, v2_result.flagged_issues)
+
+        record = {
+            "id": sha,
+            "subject": pr["subject"],
+            "plant": plant,
+            "v1_chain_detected": v1_chain_detected,
+            "v1_per_stage_detected": v1_per_stage_detected,
+            "v2_detected": v2_detected,
+            "v1": {"stages": [asdict(s) for s in v1_stages]},
+            "v2": asdict(v2_result),
+        }
+        out_path = args.out / f"plant_{sha[:10]}.json"
+        out_path.write_text(json.dumps(record, indent=2))
+        summary_rows.append(record)
+        plants_done += 1
+        print(f"[{plants_done}/{args.n}] {sha[:10]}  v1_chain={v1_chain_detected}  v2={v2_detected}",
+              file=sys.stderr)
+
+    if not summary_rows:
+        print("no PRs accepted a plant; try --n larger", file=sys.stderr)
+        return 1
+
+    n = len(summary_rows)
+    v1_chain_rate = sum(r["v1_chain_detected"] for r in summary_rows) / n
+    v2_rate = sum(r["v2_detected"] for r in summary_rows) / n
+    all_miss = sum(1 for r in summary_rows
+                   if not any(r["v1_per_stage_detected"]) and not r["v2_detected"]) / n
+
+    summary_md = f"""# Bug-injection results
+
+**TLDR:** N={n} PRs each given one planted issue. V1 chain detection rate:
+{v1_chain_rate:.0%}. V2 detection rate: {v2_rate:.0%}. Both arms missed:
+{all_miss:.0%}.
+
+H3 ("correlated blind spots: ≥30% of plants missed by all 3 reviewers")
+is {'**FALSIFIED**' if all_miss < 0.30 else '**SUPPORTED**'} by these data.
+"""
+    (args.out / "summary.md").write_text(summary_md)
+    print(summary_md)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/experiments/02_qa_polling_truthfulness/bench/run_bug_injection.py
+++ b/experiments/02_qa_polling_truthfulness/bench/run_bug_injection.py
@@ -26,7 +26,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 from run_ac_self_audit import (  # noqa: E402
     build_worktree, cleanup_worktree,
     dispatch_v1, dispatch_v2,
-    list_recent_prs,
+    list_recent_prs, prune_stale_worktrees,
 )
 
 PROMPTS_DIR = Path(__file__).resolve().parent.parent / "prompts"
@@ -197,6 +197,7 @@ def main() -> int:
 
     args.out.mkdir(parents=True, exist_ok=True)
     repo = args.repo.expanduser().resolve()
+    prune_stale_worktrees(repo)
     rng = random.Random(args.seed)
 
     prs = list_recent_prs(repo, args.n * 2)  # over-sample; some lack plantable text

--- a/experiments/02_qa_polling_truthfulness/bench/run_swe_slice.sh
+++ b/experiments/02_qa_polling_truthfulness/bench/run_swe_slice.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+# run_swe_slice.sh — Run a small SWE-bench-Verified slice with each QA arm
+# wrapping a single CC builder. Compares resolved-rate, tokens, wall-clock.
+#
+# TLDR: Setup A (no QA), B (V1 mega-QA), C (V2 single), D (V3 routed).
+# Default 20-instance stratified slice (5 easy / 10 medium / 5 hard).
+#
+# Usage:
+#   bash run_swe_slice.sh --n 20 --out ~/dfs/qa-polling-results/swe-slice/<date>/
+#
+# Prereqs:
+#   - SWE-bench Verified env installed locally (https://www.swebench.com)
+#   - At minimum: `pip install swebench` and a runnable `swebench/harness/run_evaluation.py`
+#   - clauded / codex / gemini CLIs authed for the QA arms
+#   - Anthropic-credentialed CC for the builder (subscription via clauded)
+#
+# This script is intentionally a wrapper around the SWE-bench harness — it
+# does NOT re-implement evaluation. It produces:
+#   OUT/setup_A/results.json   # baseline
+#   OUT/setup_B/results.json   # +V1 mega-QA
+#   OUT/setup_C/results.json   # +V2 single-judge
+#   OUT/setup_D/results.json   # +V3 routed
+#   OUT/summary.md             # consolidated table
+
+set -euo pipefail
+
+N=20
+OUT=""
+SLICE_FILE="$(dirname "$0")/swe_slice_default.txt"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --n) N="$2"; shift 2 ;;
+    --out) OUT="$2"; shift 2 ;;
+    --slice) SLICE_FILE="$2"; shift 2 ;;
+    --help|-h)
+      sed -n '1,/^set -euo/p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0 ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+if [[ -z "$OUT" ]]; then
+  echo "ERROR: --out is required" >&2
+  exit 2
+fi
+
+mkdir -p "$OUT"
+
+# Sanity: SWE-bench installed?
+if ! python -c "import swebench" 2>/dev/null; then
+  cat <<EOF >&2
+ERROR: swebench package not importable.
+Install it once with:
+  python -m pip install --user swebench
+Or follow the official setup at https://www.swebench.com.
+This script does NOT bootstrap SWE-bench — too many environment-specific
+choices (Docker vs native, Python version, model harness).
+EOF
+  exit 3
+fi
+
+# Sanity: builder CLI present?
+if ! command -v clauded >/dev/null 2>&1; then
+  echo "ERROR: clauded not on PATH — needed as the builder." >&2
+  exit 3
+fi
+
+# Default slice: 20 instance IDs sampled across difficulty deciles.
+# We do NOT hard-code instance IDs here (they evolve with SWE-bench releases).
+# Instead, generate the slice on first run and cache it for reproducibility.
+if [[ ! -f "$SLICE_FILE" ]]; then
+  echo "Generating $N-instance stratified slice (cached at $SLICE_FILE)..."
+  python - "$N" "$SLICE_FILE" <<'PY'
+import json, random, sys
+n = int(sys.argv[1])
+out = sys.argv[2]
+try:
+    from datasets import load_dataset
+except ImportError:
+    print("pip install datasets first", file=sys.stderr); sys.exit(3)
+ds = load_dataset("princeton-nlp/SWE-bench_Verified", split="test")
+# stratify on FAIL_TO_PASS length as a rough difficulty proxy
+items = [(i, len(json.loads(r["FAIL_TO_PASS"])) if r.get("FAIL_TO_PASS") else 0)
+         for i, r in enumerate(ds)]
+items.sort(key=lambda x: x[1])
+buckets = 3  # easy / medium / hard
+per = [n // buckets] * buckets
+for i in range(n - sum(per)):
+    per[i] += 1
+random.seed(42)
+chosen = []
+chunk = max(1, len(items) // buckets)
+for b, k in enumerate(per):
+    bucket = items[b*chunk : (b+1)*chunk]
+    chosen.extend(random.sample(bucket, min(k, len(bucket))))
+ids = [ds[i]["instance_id"] for i, _ in chosen]
+with open(out, "w") as f:
+    f.write("\n".join(ids))
+print(f"wrote {len(ids)} instance ids -> {out}")
+PY
+fi
+
+PROMPTS_DIR="$(cd "$(dirname "$0")/.." && pwd)/prompts"
+
+run_one_setup () {
+  local label="$1"
+  local qa_arm="$2"      # none | v1 | v2 | v3
+  local outdir="$OUT/setup_${label}"
+  mkdir -p "$outdir"
+
+  echo ">>> Setup $label (qa=$qa_arm) — writing to $outdir"
+
+  # The harness loop: for each instance,
+  #   1. clauded builder produces a patch
+  #   2. if qa_arm != none, dispatch the corresponding QA prompt against the patch
+  #   3. swebench harness scores the (possibly-fixed) patch
+  python - "$SLICE_FILE" "$outdir" "$qa_arm" "$PROMPTS_DIR" <<'PY'
+import json, os, subprocess, sys, time
+from pathlib import Path
+
+slice_path, outdir, qa_arm, prompts_dir = sys.argv[1:5]
+instance_ids = Path(slice_path).read_text().strip().splitlines()
+results = []
+t_start = time.monotonic()
+
+builder_prompt = (
+    "You are solving a SWE-bench Verified instance. Produce a minimal git "
+    "patch that resolves the issue. Use the existing test suite as your "
+    "verifier. Do not introduce unrelated changes."
+)
+
+qa_prompt_path = {
+    "v1": Path(prompts_dir) / "qa_v1_polling_baseline.md",
+    "v2": Path(prompts_dir) / "qa_v2_verifier_first.md",
+    "v3": Path(prompts_dir) / "qa_v3_verifier_routed.md",
+}.get(qa_arm)
+
+for iid in instance_ids:
+    record = {"instance_id": iid, "qa_arm": qa_arm,
+              "build_seconds": None, "qa_seconds": None,
+              "patch_applied": False, "swebench_resolved": None}
+    t0 = time.monotonic()
+    # 1. Builder. We assume a thin wrapper script `swebench-build-instance`
+    # has been provided locally. If not, mark instance as skipped.
+    builder = subprocess.run(
+        ["swebench-build-instance", iid, "--prompt", builder_prompt],
+        capture_output=True, text=True, timeout=3600,
+    )
+    record["build_seconds"] = time.monotonic() - t0
+    if builder.returncode != 0:
+        record["error"] = "builder_failed"
+        results.append(record); continue
+    record["patch_applied"] = True
+
+    # 2. QA arm.
+    if qa_arm != "none" and qa_prompt_path and qa_prompt_path.exists():
+        t1 = time.monotonic()
+        qa = subprocess.run(
+            ["swebench-qa-instance", iid, "--prompt-file", str(qa_prompt_path),
+             "--arm", qa_arm],
+            capture_output=True, text=True, timeout=3600,
+        )
+        record["qa_seconds"] = time.monotonic() - t1
+        if qa.returncode != 0:
+            record["error"] = "qa_failed"
+
+    # 3. Score with SWE-bench harness.
+    score = subprocess.run(
+        ["python", "-m", "swebench.harness.run_evaluation",
+         "--instance_id", iid, "--predictions_path",
+         f"{outdir}/predictions.jsonl"],
+        capture_output=True, text=True, timeout=1800,
+    )
+    record["swebench_resolved"] = "RESOLVED" in score.stdout
+    results.append(record)
+
+Path(outdir, "results.json").write_text(json.dumps(results, indent=2))
+total = time.monotonic() - t_start
+print(f"setup done in {total:.0f}s; {sum(1 for r in results if r['swebench_resolved'])} resolved out of {len(results)}")
+PY
+}
+
+run_one_setup A none
+run_one_setup B v1
+run_one_setup C v2
+run_one_setup D v3
+
+# Consolidated summary
+python - "$OUT" <<'PY'
+import json
+from pathlib import Path
+import sys
+out = Path(sys.argv[1])
+rows = ["| setup | resolved | total | resolved_pct | mean_qa_s |", "|---|---|---|---|---|"]
+for label in ("A", "B", "C", "D"):
+    rp = out / f"setup_{label}" / "results.json"
+    if not rp.exists():
+        rows.append(f"| {label} | - | - | - | - |"); continue
+    data = json.loads(rp.read_text())
+    n = len(data)
+    res = sum(1 for r in data if r.get("swebench_resolved"))
+    qa = [r["qa_seconds"] for r in data if r.get("qa_seconds")]
+    qa_mean = sum(qa)/len(qa) if qa else 0.0
+    rows.append(f"| {label} | {res} | {n} | {100.0*res/n:.1f}% | {qa_mean:.0f} |")
+(out / "summary.md").write_text(
+    "# SWE-bench Verified slice — QA arm comparison\n\n"
+    "**TLDR:** Per-setup resolved-rate on a small SWE-bench Verified slice. "
+    "A = no QA, B = V1 mega-QA, C = V2 single+verifier, D = V3 routed.\n\n"
+    + "\n".join(rows) + "\n"
+)
+print((out / "summary.md").read_text())
+PY

--- a/experiments/02_qa_polling_truthfulness/bench/run_swe_slice.sh
+++ b/experiments/02_qa_polling_truthfulness/bench/run_swe_slice.sh
@@ -66,6 +66,24 @@ if ! command -v clauded >/dev/null 2>&1; then
   exit 3
 fi
 
+# Sanity: SWE-bench thin wrappers present? These are NOT installed by the
+# upstream swebench package — they are local helpers expected to live on PATH
+# and to: (a) build a candidate patch for an instance, (b) optionally invoke a
+# QA arm against the patch. If missing, every per-instance step would silently
+# record builder_failed; surface the missing-tool error up front instead.
+for tool in swebench-build-instance swebench-qa-instance; do
+  if ! command -v "$tool" >/dev/null 2>&1; then
+    cat <<EOF >&2
+ERROR: '$tool' not on PATH. This script wraps a thin local helper that is
+expected to call the SWE-bench harness for one instance. Provide a script of
+that name (in PATH) that accepts the documented args (see lines marked
+'1. Builder' and '2. QA arm' inside this file). Without it, every instance
+will be marked builder_failed.
+EOF
+    exit 3
+  fi
+done
+
 # Default slice: 20 instance IDs sampled across difficulty deciles.
 # We do NOT hard-code instance IDs here (they evolve with SWE-bench releases).
 # Instead, generate the slice on first run and cache it for reproducibility.

--- a/experiments/02_qa_polling_truthfulness/bench/vibe_check.py
+++ b/experiments/02_qa_polling_truthfulness/bench/vibe_check.py
@@ -1,0 +1,323 @@
+#!/usr/bin/env python3
+"""
+vibe_check.py — Surface 5 best/worst examples from ac-self-audit results
+for Brando to eyeball-rate, plus an Opus-4.7 auto-judge per example so we
+can later compare auto vs human and stop needing the human pass.
+
+TLDR: Reads run_ac_self_audit.py output, ranks by V1/V2 disagreement,
+writes per-example side-by-side markdowns + a pre-rating from an LLM judge.
+
+Usage:
+    python vibe_check.py --in IN_DIR --out OUT_DIR --k 5
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shlex
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+JUDGE_PROMPT_TEMPLATE = """\
+You are a meta-judge comparing two QA reviews of the same code diff. Decide
+which review's set of flagged issues is more useful to a human maintainer.
+
+GROUND RULES:
+- "More useful" means: catches real bugs, omits false alarms, gives actionable
+  citations. Cosmetic flags ("could be cleaner") count less than correctness
+  flags ("this overwrites the wrong path").
+- If both reviews flag mostly the same real issues, return TIE — do not break
+  ties on count.
+- If one review made up issues that don't exist in the diff, that's a strong
+  vote against it.
+- You may NOT see the ground truth. Reason from the diff and the flagged
+  issues alone.
+
+DIFF (truncated to 8k chars):
+{diff}
+
+REVIEW A flagged issues:
+{a_flags}
+REVIEW A summary: {a_summary}
+
+REVIEW B flagged issues:
+{b_flags}
+REVIEW B summary: {b_summary}
+
+Output exactly one of: A | B | TIE
+Then a one-sentence reason.
+"""
+
+
+def load_results(in_dir: Path) -> list[dict]:
+    records = []
+    for f in sorted(in_dir.glob("pr_*.json")):
+        try:
+            records.append(json.loads(f.read_text()))
+        except json.JSONDecodeError:
+            print(f"skip malformed {f}", file=sys.stderr)
+    return records
+
+
+def disagreement_score(rec: dict) -> float:
+    """1 - jaccard(V1, V2). Higher = more disagreement = more interesting."""
+    return 1.0 - rec.get("agreement", {}).get("v1_v2_jaccard", 1.0)
+
+
+def all_v1_flags(rec: dict) -> list:
+    return [f for s in rec.get("v1", {}).get("stages", [])
+            for f in s.get("flagged_issues", [])]
+
+
+def v2_flags(rec: dict) -> list:
+    return rec.get("v2", {}).get("flagged_issues", [])
+
+
+def v1_summary(rec: dict) -> str:
+    stages = rec.get("v1", {}).get("stages", [])
+    return " | ".join(s.get("summary", "") for s in stages if s.get("summary"))
+
+
+def v2_summary(rec: dict) -> str:
+    return rec.get("v2", {}).get("summary", "")
+
+
+def render_example(rec: dict, idx: int, ab_swap: bool) -> str:
+    """Side-by-side markdown for one example. ab_swap randomizes which arm is
+    labeled A vs B so the human's rating is at least order-blind."""
+    arm_a, arm_b = ("v1", "v2") if not ab_swap else ("v2", "v1")
+    a_flags = all_v1_flags(rec) if arm_a == "v1" else v2_flags(rec)
+    b_flags = all_v1_flags(rec) if arm_b == "v1" else v2_flags(rec)
+    a_sum = v1_summary(rec) if arm_a == "v1" else v2_summary(rec)
+    b_sum = v1_summary(rec) if arm_b == "v1" else v2_summary(rec)
+    return f"""# Example {idx:02d} — {rec.get('subject', '<no subject>')}
+
+**TLDR:** Side-by-side QA review for SHA `{rec.get('id', '')[:10]}`.
+Disagreement: jaccard distance = {disagreement_score(rec):.2f}.
+
+## Diff summary
+- files changed: {rec['diff_summary']['files_changed']}
+- additions: {rec['diff_summary']['additions']}
+- deletions: {rec['diff_summary']['deletions']}
+- languages: {', '.join(rec['diff_summary']['languages'])}
+- runnable verifier present: {rec['diff_summary']['has_runnable_verifier']}
+
+## Review A — flagged issues
+{_render_flags(a_flags)}
+**Summary:** {a_sum}
+
+## Review B — flagged issues
+{_render_flags(b_flags)}
+**Summary:** {b_sum}
+
+---
+
+## Brando's rating (fill in)
+
+`A` / `B` / `T` (tie):
+
+Reason (one sentence):
+
+---
+
+(Order is randomized: see `mapping.json` to decode.)
+"""
+
+
+def _render_flags(flags: list) -> str:
+    if not flags:
+        return "_(none)_"
+    rows = []
+    for f in flags[:25]:
+        loc = f.get("file", "?")
+        if f.get("line"):
+            loc += f":{f['line']}"
+        rows.append(f"- `{loc}` — {f.get('claim', '')}")
+    if len(flags) > 25:
+        rows.append(f"- _(+{len(flags) - 25} more)_")
+    return "\n".join(rows)
+
+
+def auto_judge(rec: dict, ab_swap: bool, repo: Path | None = None) -> dict:
+    """Dispatch a single best-model to auto-rate which arm is more useful.
+    Falls back to "no_judge_available" if no CLI is on PATH."""
+    arm_a, arm_b = ("v1", "v2") if not ab_swap else ("v2", "v1")
+    diff_text = ""
+    if repo:
+        try:
+            diff_text = subprocess.run(
+                ["git", "-C", str(repo), "diff",
+                 f"{rec['id']}^1..{rec['id']}"],
+                capture_output=True, text=True, timeout=30,
+            ).stdout[:8000]
+        except Exception:
+            pass
+
+    prompt = JUDGE_PROMPT_TEMPLATE.format(
+        diff=diff_text or "(diff unavailable)",
+        a_flags=json.dumps(all_v1_flags(rec) if arm_a == "v1" else v2_flags(rec),
+                           indent=2)[:4000],
+        a_summary=v1_summary(rec) if arm_a == "v1" else v2_summary(rec),
+        b_flags=json.dumps(all_v1_flags(rec) if arm_b == "v1" else v2_flags(rec),
+                           indent=2)[:4000],
+        b_summary=v1_summary(rec) if arm_b == "v1" else v2_summary(rec),
+    )
+
+    for cli in (["clauded", "-p"], ["codex", "exec", "--full-auto"], ["gemini", "-p"]):
+        if shutil.which(cli[0]):
+            try:
+                proc = subprocess.run(cli + [prompt], capture_output=True,
+                                      text=True, timeout=600)
+                pick = _parse_judge(proc.stdout)
+                return {"judge_cli": cli[0], "pick": pick,
+                        "raw": proc.stdout[-500:]}
+            except subprocess.TimeoutExpired:
+                continue
+    return {"judge_cli": "none", "pick": "no_judge_available", "raw": ""}
+
+
+def _parse_judge(text: str) -> str:
+    for line in text.strip().splitlines():
+        token = line.strip().split()
+        if token and token[0] in {"A", "B", "TIE"}:
+            return token[0]
+    return "unparseable"
+
+
+def write_summary(records: list[dict], out_dir: Path) -> None:
+    n = len(records)
+    if n == 0:
+        return
+
+    def avg(key, default=0.0):
+        return sum(r["agreement"].get(key, default) for r in records) / n
+
+    def avg_int(arm: str, field: str) -> float:
+        vals = []
+        for r in records:
+            if arm == "v1":
+                vals.extend(s.get(field, 0)
+                            for s in r.get("v1", {}).get("stages", []))
+            else:
+                vals.append(r.get(arm, {}).get(field, 0))
+        return sum(vals) / max(1, len(vals))
+
+    summary = f"""# Vibe-check summary
+
+**TLDR:** Averaged across {n} PRs from ac-self-audit. V1/V2 jaccard
+agreement = {avg('v1_v2_jaccard'):.2f} (1 = identical flagged sets).
+
+## Per-arm averages
+
+| arm | avg flagged | avg fixes | avg wall_time_s |
+|---|---|---|---|
+| V1 (mega-QA) | {avg_int('v1', 'critical_issues') + avg_int('v1', 'major_issues'):.2f} | {avg_int('v1', 'fixes_applied'):.2f} | {avg_int('v1', 'wall_time_s'):.1f} |
+| V2 (single)  | {avg_int('v2', 'critical_issues') + avg_int('v2', 'major_issues'):.2f} | {avg_int('v2', 'fixes_applied'):.2f} | {avg_int('v2', 'wall_time_s'):.1f} |
+
+## Pairwise agreement
+
+- V1 vs V2 jaccard: {avg('v1_v2_jaccard'):.2f}
+- V1 vs V3 jaccard: {avg('v1_v3_jaccard'):.2f}
+- V2 vs V3 jaccard: {avg('v2_v3_jaccard'):.2f}
+
+A jaccard near 1.0 with V1 doing 3x the work and producing the same flagged
+set is the signal the paper warns about — extra cost, no extra information.
+
+## Next steps
+
+1. Open each `examples/example_NN.md` and fill in your A/B/T rating.
+2. Run `python vibe_check.py --score-human --in OUT_DIR` to compute
+   Brando-vs-auto-judge agreement.
+3. If auto-judge agreement >= 80% across 10+ examples, future rounds can
+   skip the human pass and trust the auto-judge.
+"""
+    (out_dir / "summary.md").write_text(summary)
+
+
+def cmd_main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--in", dest="in_dir", type=Path, required=True)
+    ap.add_argument("--out", type=Path, required=True)
+    ap.add_argument("--k", type=int, default=5)
+    ap.add_argument("--repo", type=Path,
+                    default=Path.home() / "agents-config")
+    ap.add_argument("--score-human", action="store_true",
+                    help="Re-score Brando-vs-auto agreement (after rating).")
+    args = ap.parse_args(argv)
+
+    args.out.mkdir(parents=True, exist_ok=True)
+    examples_dir = args.out / "examples"
+    examples_dir.mkdir(exist_ok=True)
+
+    records = load_results(args.in_dir)
+    if not records:
+        print(f"no results in {args.in_dir}", file=sys.stderr)
+        return 1
+
+    if args.score_human:
+        return _score_human(args.out)
+
+    records.sort(key=disagreement_score, reverse=True)
+    top = records[:args.k]
+
+    mapping = {}
+    auto = {}
+    for i, rec in enumerate(top, start=1):
+        ab_swap = (hash(rec.get("id", "")) % 2 == 0)
+        md = render_example(rec, i, ab_swap)
+        (examples_dir / f"example_{i:02d}.md").write_text(md)
+        mapping[f"example_{i:02d}"] = {
+            "id": rec.get("id"),
+            "ab_swap": ab_swap,
+            "arm_A": "v2" if ab_swap else "v1",
+            "arm_B": "v1" if ab_swap else "v2",
+        }
+        auto[f"example_{i:02d}"] = auto_judge(rec, ab_swap, args.repo)
+
+    (args.out / "mapping.json").write_text(json.dumps(mapping, indent=2))
+    (args.out / "auto_judge.json").write_text(json.dumps(auto, indent=2))
+    write_summary(records, args.out)
+    print(f"wrote {len(top)} examples to {examples_dir}/")
+    print(f"summary at {args.out / 'summary.md'}")
+    return 0
+
+
+def _score_human(out: Path) -> int:
+    """Read human ratings from each example_NN.md, compare to auto_judge.json."""
+    auto = json.loads((out / "auto_judge.json").read_text())
+    mapping = json.loads((out / "mapping.json").read_text())
+    rows = []
+    for name, judge in auto.items():
+        path = out / "examples" / f"{name}.md"
+        if not path.exists():
+            continue
+        text = path.read_text()
+        human = "unrated"
+        if "Brando's rating (fill in)" in text:
+            after = text.split("Brando's rating (fill in)", 1)[1]
+            for line in after.splitlines():
+                t = line.strip().strip("`").upper()
+                if t in {"A", "B", "T", "TIE"}:
+                    human = "TIE" if t == "T" else t
+                    break
+        rows.append({"example": name, "human": human, "auto": judge["pick"],
+                     "agree": human == judge["pick"]})
+    rated = [r for r in rows if r["human"] != "unrated"
+             and r["auto"] not in {"no_judge_available", "unparseable"}]
+    if not rated:
+        print("no rated examples to score", file=sys.stderr)
+        return 1
+    agree_pct = 100.0 * sum(r["agree"] for r in rated) / len(rated)
+    (out / "agreement.json").write_text(json.dumps(
+        {"per_example": rows, "agree_pct": agree_pct,
+         "n_rated": len(rated)}, indent=2))
+    print(f"Brando vs auto-judge agreement: {agree_pct:.0f}% across {len(rated)} examples")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(cmd_main())

--- a/experiments/02_qa_polling_truthfulness/bench/vibe_check.py
+++ b/experiments/02_qa_polling_truthfulness/bench/vibe_check.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 import argparse
 import json
-import shlex
+import re
 import shutil
 import subprocess
 import sys
@@ -188,6 +188,38 @@ def _parse_judge(text: str) -> str:
     return "unparseable"
 
 
+def _extract_human_rating(text: str) -> str:
+    """Pull Brando's rating out of a filled-in example_NN.md. Tolerates both
+    "answer on its own line" and "answer inline after the prompt colon"
+    formats. Skips the unfilled-template line itself (which contains all of
+    A / B / T as backticked option markers)."""
+    marker = "Brando's rating (fill in)"
+    if marker not in text:
+        return "unrated"
+    after = text.split(marker, 1)[1]
+    template_re = re.compile(r"`A`\s*/\s*`B`\s*/\s*`T`")
+    inline_re = re.compile(r":\s*`?([ABT]|TIE)`?\s*$", re.IGNORECASE)
+    standalone_re = re.compile(r"^\s*`?([ABT]|TIE)`?\s*$", re.IGNORECASE)
+    for raw in after.splitlines():
+        line = raw.rstrip()
+        is_template = bool(template_re.search(line))
+        m_inline = inline_re.search(line)
+        if is_template and m_inline:
+            token = m_inline.group(1).upper()
+            return "TIE" if token == "T" else token
+        if is_template:
+            continue
+        m_inline = inline_re.search(line)
+        if m_inline:
+            token = m_inline.group(1).upper()
+            return "TIE" if token == "T" else token
+        m_alone = standalone_re.match(line)
+        if m_alone:
+            token = m_alone.group(1).upper()
+            return "TIE" if token == "T" else token
+    return "unrated"
+
+
 def write_summary(records: list[dict], out_dir: Path) -> None:
     n = len(records)
     if n == 0:
@@ -296,14 +328,7 @@ def _score_human(out: Path) -> int:
         if not path.exists():
             continue
         text = path.read_text()
-        human = "unrated"
-        if "Brando's rating (fill in)" in text:
-            after = text.split("Brando's rating (fill in)", 1)[1]
-            for line in after.splitlines():
-                t = line.strip().strip("`").upper()
-                if t in {"A", "B", "T", "TIE"}:
-                    human = "TIE" if t == "T" else t
-                    break
+        human = _extract_human_rating(text)
         rows.append({"example": name, "human": human, "auto": judge["pick"],
                      "agree": human == judge["pick"]})
     rated = [r for r in rows if r["human"] != "unrated"

--- a/experiments/02_qa_polling_truthfulness/bench/vibe_check.py
+++ b/experiments/02_qa_polling_truthfulness/bench/vibe_check.py
@@ -142,41 +142,50 @@ def _render_flags(flags: list) -> str:
     return "\n".join(rows)
 
 
+def _arm_flags(rec: dict, arm: str) -> list:
+    return all_v1_flags(rec) if arm == "v1" else v2_flags(rec)
+
+
+def _arm_summary(rec: dict, arm: str) -> str:
+    return v1_summary(rec) if arm == "v1" else v2_summary(rec)
+
+
+def _git_diff_for(rec: dict, repo: Path | None) -> str:
+    if not repo:
+        return ""
+    try:
+        return subprocess.run(
+            ["git", "-C", str(repo), "diff", f"{rec['id']}^1..{rec['id']}"],
+            capture_output=True, text=True, timeout=30,
+        ).stdout[:8000]
+    except Exception:
+        return ""
+
+
+_JUDGE_CLIS = (["clauded", "-p"], ["codex", "exec", "--full-auto"], ["gemini", "-p"])
+
+
 def auto_judge(rec: dict, ab_swap: bool, repo: Path | None = None) -> dict:
     """Dispatch a single best-model to auto-rate which arm is more useful.
     Falls back to "no_judge_available" if no CLI is on PATH."""
-    arm_a, arm_b = ("v1", "v2") if not ab_swap else ("v2", "v1")
-    diff_text = ""
-    if repo:
-        try:
-            diff_text = subprocess.run(
-                ["git", "-C", str(repo), "diff",
-                 f"{rec['id']}^1..{rec['id']}"],
-                capture_output=True, text=True, timeout=30,
-            ).stdout[:8000]
-        except Exception:
-            pass
-
+    arm_a, arm_b = ("v2", "v1") if ab_swap else ("v1", "v2")
     prompt = JUDGE_PROMPT_TEMPLATE.format(
-        diff=diff_text or "(diff unavailable)",
-        a_flags=json.dumps(all_v1_flags(rec) if arm_a == "v1" else v2_flags(rec),
-                           indent=2)[:4000],
-        a_summary=v1_summary(rec) if arm_a == "v1" else v2_summary(rec),
-        b_flags=json.dumps(all_v1_flags(rec) if arm_b == "v1" else v2_flags(rec),
-                           indent=2)[:4000],
-        b_summary=v1_summary(rec) if arm_b == "v1" else v2_summary(rec),
+        diff=_git_diff_for(rec, repo) or "(diff unavailable)",
+        a_flags=json.dumps(_arm_flags(rec, arm_a), indent=2)[:4000],
+        a_summary=_arm_summary(rec, arm_a),
+        b_flags=json.dumps(_arm_flags(rec, arm_b), indent=2)[:4000],
+        b_summary=_arm_summary(rec, arm_b),
     )
-
-    for cli in (["clauded", "-p"], ["codex", "exec", "--full-auto"], ["gemini", "-p"]):
-        if shutil.which(cli[0]):
-            try:
-                proc = subprocess.run(cli + [prompt], capture_output=True,
-                                      text=True, timeout=600)
-                pick = _parse_judge(proc.stdout)
-                return {"judge_cli": cli[0], "pick": pick,
-                        "raw": proc.stdout[-500:]}
-            except subprocess.TimeoutExpired:
-                continue
+    for cli in _JUDGE_CLIS:
+        if not shutil.which(cli[0]):
+            continue
+        try:
+            proc = subprocess.run(cli + [prompt], capture_output=True,
+                                  text=True, timeout=600)
+        except subprocess.TimeoutExpired:
+            continue
+        return {"judge_cli": cli[0], "pick": _parse_judge(proc.stdout),
+                "raw": proc.stdout[-500:]}
     return {"judge_cli": "none", "pick": "no_judge_available", "raw": ""}
 
 
@@ -188,35 +197,39 @@ def _parse_judge(text: str) -> str:
     return "unparseable"
 
 
+_TEMPLATE_RE = re.compile(r"`A`\s*/\s*`B`\s*/\s*`T`")
+_INLINE_RE = re.compile(r":\s*`?([ABT]|TIE)`?\s*$", re.IGNORECASE)
+_STANDALONE_RE = re.compile(r"^\s*`?([ABT]|TIE)`?\s*$", re.IGNORECASE)
+
+
+def _normalize_rating(token: str) -> str:
+    token = token.upper()
+    return "TIE" if token == "T" else token
+
+
 def _extract_human_rating(text: str) -> str:
     """Pull Brando's rating out of a filled-in example_NN.md. Tolerates both
     "answer on its own line" and "answer inline after the prompt colon"
     formats. Skips the unfilled-template line itself (which contains all of
-    A / B / T as backticked option markers)."""
+    A / B / T as backticked option markers) unless that line itself has an
+    inline answer appended."""
     marker = "Brando's rating (fill in)"
     if marker not in text:
         return "unrated"
     after = text.split(marker, 1)[1]
-    template_re = re.compile(r"`A`\s*/\s*`B`\s*/\s*`T`")
-    inline_re = re.compile(r":\s*`?([ABT]|TIE)`?\s*$", re.IGNORECASE)
-    standalone_re = re.compile(r"^\s*`?([ABT]|TIE)`?\s*$", re.IGNORECASE)
     for raw in after.splitlines():
         line = raw.rstrip()
-        is_template = bool(template_re.search(line))
-        m_inline = inline_re.search(line)
+        is_template = bool(_TEMPLATE_RE.search(line))
+        m_inline = _INLINE_RE.search(line)
         if is_template and m_inline:
-            token = m_inline.group(1).upper()
-            return "TIE" if token == "T" else token
+            return _normalize_rating(m_inline.group(1))
         if is_template:
             continue
-        m_inline = inline_re.search(line)
         if m_inline:
-            token = m_inline.group(1).upper()
-            return "TIE" if token == "T" else token
-        m_alone = standalone_re.match(line)
+            return _normalize_rating(m_inline.group(1))
+        m_alone = _STANDALONE_RE.match(line)
         if m_alone:
-            token = m_alone.group(1).upper()
-            return "TIE" if token == "T" else token
+            return _normalize_rating(m_alone.group(1))
     return "unrated"
 
 

--- a/experiments/02_qa_polling_truthfulness/prompts/qa_v1_polling_baseline.md
+++ b/experiments/02_qa_polling_truthfulness/prompts/qa_v1_polling_baseline.md
@@ -1,0 +1,108 @@
+# QA Prompt v1 — Polling Baseline (Control Arm)
+
+**TLDR:** This is the current mega-QA chain (Codex → CC → Gemini sequential,
+each with fix authority), restated verbatim as the **control arm** for
+experiment 02. Identical to `~/agents-config/workflows/qa-correctness.md`
+mega-QA so any change in measured usefulness can only be attributed to V2/V3,
+not to a prompt difference inside V1.
+
+---
+
+## When this is used
+
+V1 is the baseline that V2 (single-judge + verifier) and V3 (verifier-routed)
+are compared against. Do **not** edit V1 to "fix" issues you find — V1 must
+match production mega-QA exactly so the comparison is fair. If production
+mega-QA changes, copy the new version here and bump to v1.1.
+
+## Pinned source-of-truth references
+
+- Reviewer dispatch: `~/agents-config/workflows/qa-correctness.md`
+- Mega-QA chain: `~/agents-config/INDEX_RULES.md` Trigger Rule 10
+- Verdict format (must match exactly): see "Verdict Format" below.
+
+---
+
+## V1 chain (production mega-QA, restated)
+
+Three sequential stages. Each stage runs the same prompt on the code as
+improved by the previous stage. Last verdict wins.
+
+| Stage | Reviewer | Role |
+|---|---|---|
+| 1 | Codex (or CC if Codex built) | First independent reviewer |
+| 2 | The builder (CC or Codex) | Knows intent best, verifies stage 1's fixes |
+| 3 | Gemini | Clean-eyes final pass |
+
+If a reviewer CLI is unavailable, fall back per `qa-correctness.md` § Single-model
+fallback: re-dispatch with the next available CLI; never use API keys.
+
+---
+
+## Per-stage prompt (verbatim)
+
+```
+Review all changes in this directory since the last commit on main.
+
+CORRECTNESS: Flag and fix critical and major issues — logic errors, missing
+edge cases, incorrect behavior, inconsistencies with project agent docs (for
+example ~/your-project/docs/agent-docs/, if present).
+
+STRUCTURAL (skip for markdown-only repos): Check for god functions (CC > 10
+or >60 lines), structural duplication, verbose anti-patterns (single-use vars,
+identity wrappers, defensive checks for impossible states, 3+ nesting,
+if/elif ladders, dead code). Fix what you find. Preserve public interfaces.
+Run tests after each change — revert and skip if tests break.
+
+You are empowered to fix issues directly. Apply minimal fixes only.
+
+End with exactly:
+VERDICT: PASS | FAIL | FIXED
+CRITICAL_ISSUES: [count]
+MAJOR_ISSUES: [count]
+FIXES_APPLIED: [count]
+STRUCTURAL: PASS | IMPROVED | SKIP
+SUMMARY: [1-2 sentences]
+If everything looks correct, use PASS with all counts 0.
+```
+
+---
+
+## Logging requirements (for experiment 02)
+
+Each stage must additionally emit, to `stderr` or a sidecar JSON, the
+following so the bench scripts can parse:
+
+```json
+{
+  "stage": 1 | 2 | 3,
+  "reviewer": "codex" | "cc" | "gemini",
+  "verdict": "PASS" | "FAIL" | "FIXED",
+  "critical_issues": <int>,
+  "major_issues": <int>,
+  "fixes_applied": <int>,
+  "structural": "PASS" | "IMPROVED" | "SKIP",
+  "summary": "<string>",
+  "flagged_issues": [{"file": "<path>", "line": <int|null>, "claim": "<str>"}],
+  "applied_fix_diff": "<unified diff or null>",
+  "tokens_in": <int>,
+  "tokens_out": <int>,
+  "wall_time_s": <float>
+}
+```
+
+This shape is what `bench/run_ac_self_audit.py` expects. The verdict block in
+plain text remains unchanged so production behavior is unaffected.
+
+---
+
+## Notes for experimenters
+
+- **Do not patch V1 to fix prompt bugs you spot here.** Open a separate PR
+  against `workflows/qa-correctness.md` if you want to change production. V1
+  exists as a fixed reference point.
+- **V1 may print "STRUCTURAL: SKIP" on markdown repos.** That's expected and
+  is not a bug.
+- **Budget:** typical V1 run on a small markdown-only PR is ~20-30k tokens
+  per stage = ~60-90k total. Code PRs with substantial diff can run ~150-300k
+  total.

--- a/experiments/02_qa_polling_truthfulness/prompts/qa_v2_verifier_first.md
+++ b/experiments/02_qa_polling_truthfulness/prompts/qa_v2_verifier_first.md
@@ -1,0 +1,132 @@
+# QA Prompt v2 — Single Best-Model + Verifier-First (Treatment Arm)
+
+**TLDR:** One reviewer (best-available model with extended thinking), required
+to either run an external verifier (tests / lint / type-check / build) **or**
+produce explicit citations (file:line, URL) for every claim it ratifies.
+Removes the cross-model ratification step the paper suggests is mostly
+correlated noise.
+
+---
+
+## Why this exists
+
+Per `analysis.md` §1–§3, the paper's failure mode is "verifier-absent +
+correlated priors." V2's design rule: never ratify a verdict by stacking
+correlated judgments. Either the verdict is anchored to a verifier (tests,
+lint, type-check, build, deterministic measurement), or it is anchored to a
+citation (a specific file:line or URL the human can check). If neither is
+possible, the verdict is downgraded from PASS/FIXED to **DEFER** — explicit
+flag for human review.
+
+---
+
+## Reviewer dispatch
+
+- **Single reviewer:** best available CLI in current environment.
+  - Preference: `clauded -p` with Opus 4.7 + extended thinking enabled.
+  - Fallback: `codex exec --full-auto` on best Codex model.
+  - Last resort: `gemini -p`.
+- **No second or third stage.** That's the entire point of the treatment.
+- **Cost target:** roughly 2× a single V1 stage (extended thinking + verifier
+  invocation) but still ~⅔ to ½ the cost of full V1 mega-QA.
+
+---
+
+## Per-run prompt (verbatim)
+
+```
+Review all changes in this directory since the last commit on main.
+
+You are the SOLE reviewer for this diff. There is no second pass. Your verdict
+is final. Adjust your standards accordingly: do not assume someone else will
+catch what you miss.
+
+GROUND RULES:
+
+1. VERIFIER FIRST. Before forming any verdict on correctness, identify what
+   external verifier(s) are applicable to this diff and run them:
+     - Source code: tests (pytest / npm test / cargo test), linter, type
+       checker, build. Run what exists. Do not skip because slow — set a
+       timeout and report partial results if needed.
+     - Markdown / config: link checker, schema validator, structural metrics
+       (radon for any .py touched), `git grep` for cross-references that the
+       diff might have broken.
+     - If NO external verifier is applicable, say so explicitly in the
+       SUMMARY.
+   Record verifier output in your report.
+
+2. CITE OR DEFER. For every CRITICAL or MAJOR issue you flag, include either:
+     (a) a verifier output excerpt that demonstrates the issue, or
+     (b) a file:line citation that the human can open and read.
+   For every PASS verdict you give on a non-trivial diff, include either:
+     (a) verifier output showing the relevant tests/checks pass, or
+     (b) at least one file:line citation showing you actually read the
+         changed code (not just the commit message).
+   If you cannot produce either for a major question, escalate the verdict
+   to DEFER with a one-line "what would resolve this" note.
+
+3. ANTI-ANCHORING. Read the raw `git diff` BEFORE reading the commit message,
+   PR title, or any TLDR the author wrote. If after reading the diff your
+   independent read disagrees with the author's framing, say so. The crowd
+   prior is what makes correlated reviewers ratify wrong things — your job is
+   to disagree when warranted.
+
+4. CONSENSUS-AS-DEFERRAL. If you find yourself agreeing with the diff on
+   every non-trivial point with high confidence and you did not run any
+   verifier (e.g., markdown-only PR), append a "consensus warning" to your
+   SUMMARY: "high agreement, no verifier — please double-check." This is not
+   a FAIL; it is honest signal that you are doing judgment-only review.
+
+5. FIX, DON'T REWRITE. Same rules as V1: minimal fixes, preserve public
+   interfaces, revert any fix that breaks tests.
+
+STRUCTURAL (skip for markdown-only repos): Check for god functions (CC > 10
+or >60 lines), structural duplication, verbose anti-patterns. Apply the same
+"verifier or cite" rule — if you flag a god function, give file:line + the
+exact CC number from radon, not "feels too long."
+
+End with exactly:
+VERDICT: PASS | FAIL | FIXED | DEFER
+CRITICAL_ISSUES: [count]
+MAJOR_ISSUES: [count]
+FIXES_APPLIED: [count]
+STRUCTURAL: PASS | IMPROVED | SKIP
+VERIFIER_RAN: [list of tools actually invoked, or "none — judgment only"]
+CONSENSUS_WARNING: [yes | no | n/a]
+SUMMARY: [1-2 sentences. Include "judgment only" if VERIFIER_RAN is none.]
+```
+
+---
+
+## What changed vs V1, in one column
+
+- **One stage, not three.** Stops paying for ratification of correlated
+  priors.
+- **Verifier output is mandatory when applicable.** Closes the "tests
+  skipped" loophole that collapses V1 to judgment-only.
+- **Citations mandatory for every flag and every non-trivial PASS.** Forces
+  the reviewer to look at code, not just the framing.
+- **DEFER is a first-class verdict.** Honest acknowledgment that some PRs
+  cannot be reviewed without a human.
+- **CONSENSUS_WARNING flag.** Constructive use of the paper's "high agreement
+  on hard questions = blind spot" finding.
+- **VERIFIER_RAN is logged.** Lets the bench script slice results by "did
+  the reviewer actually have a verifier."
+
+---
+
+## Logging requirements (for experiment 02)
+
+Same JSON shape as V1's logging requirements, plus:
+
+```json
+{
+  "verdict": "PASS" | "FAIL" | "FIXED" | "DEFER",
+  "verifier_ran": ["pytest", "ruff", ...] | "none",
+  "consensus_warning": true | false,
+  "citations": [{"file": "<path>", "line": <int>, "claim": "<str>"}, ...]
+}
+```
+
+The bench script uses `verifier_ran == "none"` as the key slicing variable —
+those are the rows where the paper's argument applies most cleanly.

--- a/experiments/02_qa_polling_truthfulness/prompts/qa_v3_verifier_routed.md
+++ b/experiments/02_qa_polling_truthfulness/prompts/qa_v3_verifier_routed.md
@@ -1,0 +1,112 @@
+# QA Prompt v3 — Verifier-Routed (Adaptive Arm)
+
+**TLDR:** Inspect the diff first; route to V1 (mega-QA) when an external
+verifier exists and is runnable, otherwise to V2 (single-judge +
+cite-or-defer). The hypothesis is that mega-QA pays off only in the
+verifier-anchored regime, so the optimal default is to spend the cross-model
+budget there and not on prose.
+
+---
+
+## Routing rule
+
+Run this routing check **before** dispatching any reviewer. The routing
+decision and its reason go in the final report.
+
+```
+def route(diff) -> "V1" | "V2":
+    # 1. If diff touches no source code (markdown / config / docs only) → V2.
+    if all(f.suffix in {".md", ".txt", ".rst", ".json", ".yml", ".yaml",
+                        ".toml", ".tex"} for f in diff.files_changed):
+        return "V2"  # no verifier possible — paper applies → single + cite
+
+    # 2. If diff touches source code AND a runnable verifier exists in repo
+    #    (pytest / npm test / cargo / etc.) → V1.
+    if has_runnable_verifier(repo) and diff.touches_source():
+        return "V1"  # verifier-anchored → mega-QA budget pays off
+
+    # 3. Mixed or no-verifier source code → V2 with structural metrics as
+    #    partial verifier (radon / lint / type-check) + citations.
+    return "V2"
+```
+
+`has_runnable_verifier(repo)` is true if **any** of:
+- `pytest --collect-only -q` exits 0 with non-zero collected count
+- `package.json` has a `test` script and `npm test --silent --listTests`
+  reports tests
+- `Cargo.toml` exists and `cargo test --no-run` succeeds
+- `go test ./... -run XXXXX` (filter to none) exits 0
+- A `Makefile` has a `test` target that exits 0 on `make -n test`
+
+Detection should not actually run the suite, just verify it's runnable. The
+selected reviewer (V1 or V2) actually runs it.
+
+---
+
+## When V3 sends to V1
+
+Use the V1 prompt and chain (`prompts/qa_v1_polling_baseline.md`) verbatim,
+**plus** prepend this preamble:
+
+```
+ROUTING NOTE: This diff was routed to V1 (mega-QA chain) because a runnable
+external verifier exists in this repo: <list of verifiers>. Each stage MUST
+run at least one of these verifiers before producing a verdict. Stages that
+skip verification are downgraded to DEFER.
+```
+
+The "skip → DEFER" rule is the only behavior change V3 introduces to V1; it
+closes V1's main weakness (skipped tests).
+
+---
+
+## When V3 sends to V2
+
+Use V2 (`prompts/qa_v2_verifier_first.md`) verbatim — no preamble change.
+V2's "verifier first; cite or defer" already covers this case.
+
+---
+
+## Logging requirements
+
+```json
+{
+  "route_decision": "V1" | "V2",
+  "route_reason": "markdown_only" | "verifier_present" | "source_no_verifier",
+  "detected_verifiers": ["pytest", "npm-test", ...] | [],
+  ...                  # plus the V1- or V2-shaped fields per the chosen path
+}
+```
+
+---
+
+## Why this is not just "always run V1"
+
+The paper's argument: in the verifier-absent regime, paying 3× compute for 3
+correlated judges does not buy verification — it buys ratifications. So for
+markdown/config/prose diffs (a large fraction of agents-config PRs), V3
+saves ⅔ the cost while plausibly preserving the marginal value of the
+extra stages (which the paper says is small in this regime).
+
+In the verifier-present regime, the extra stages each get to *use* the
+verifier independently, so their compute does buy real additional checks.
+That's where V3 keeps V1.
+
+The routing decision can be wrong in either direction; both errors are
+recoverable:
+- **Routed to V2 but should have been V1:** Brando catches a missed bug in
+  review and re-runs as `mega-qa` explicitly.
+- **Routed to V1 but should have been V2:** the only cost is ~2× extra
+  tokens and time. No quality loss.
+
+So the routing rule is conservative: when in doubt about whether a verifier
+exists, prefer V2 (the cheaper failure mode).
+
+---
+
+## Open question
+
+Do we want a third tier "DEEP" for high-stakes diffs (security-sensitive,
+schema migrations, evaluation-metric changes) that runs V1 *and* V2 and
+escalates on disagreement? Worth considering after Tier 1 results land. For
+now, V3's two-way routing is the minimum viable adaptive policy.


### PR DESCRIPTION
## Summary

- Adds `experiments/02_qa_polling_truthfulness/` scaffold motivated by [arXiv:2603.06612](https://arxiv.org/abs/2603.06612) — paper says polling LLM samples does not improve truthfulness in verifier-absent domains because errors are structurally correlated.
- Three QA prompt variants: V1 (current mega-QA, frozen as control), V2 (single best-model + verifier-first / cite-or-defer / anti-anchoring / DEFER verdict), V3 (adaptive routing — markdown or no-verifier → V2, runnable tests → V1 with "skip→DEFER").
- Three benchmark runners: `run_ac_self_audit.py` (cheap, replays N recent PRs), `run_swe_slice.sh` (medium, 20-instance SWE-bench Verified slice across 4 setups), `run_bug_injection.py` (cheap, plants known bugs to validate H3 — correlated blind spots).
- `vibe_check.py` surfaces top-K disagreement examples for Brando's eyeball pass, randomizes A/B labels for blinding, dispatches an Opus-4.7 auto-judge per example, and computes Brando-vs-auto agreement so future rounds can skip the human pass once agreement ≥ 80%.
- **No production behavior changes** — new prompts are under `experiments/`, not wired into `INDEX_RULES.md` or `workflows/qa-*.md` until the experiments justify it.

## Test plan

- [x] `python -m py_compile` on all 3 Python runners — passes.
- [x] `bash -n run_swe_slice.sh` — passes.
- [x] Smoke-test `list_recent_prs()` against this repo's main — returns 3 PRs with `(#NN)` subjects (originally only enumerated merge commits, fixed to fall back through squash-PR pattern then last-N commits).
- [x] Smoke-test `jaccard()` tolerant matching — empty/empty=1.0, close lines=1.0, identical lists=1.0, far lines=0.0, partial overlap=0.5.
- [x] Smoke-test `dispatch_v3()` routing on a markdown-only diff — correctly routes to V2 with reason `markdown_only`.
- [x] Smoke-test prompt extraction (`_read_v1_stage_prompt`, `_read_v2_prompt`) — extracts the verbatim code blocks from the prompt files.
- [ ] Tier 1 end-to-end on snap with all three CLIs authed — **deferred to Brando's environment** (this sandbox has none of `codex` / `clauded` / `gemini` installed).

## Linked issue

Tracks #43.

## Appendix

### File layout

```
experiments/02_qa_polling_truthfulness/
├── README.md                  # overview, hypotheses, quick-start
├── analysis.md                # paper-vs-ours, threats, decision criteria
├── prompts/
│   ├── qa_v1_polling_baseline.md   # control (frozen)
│   ├── qa_v2_verifier_first.md     # treatment
│   └── qa_v3_verifier_routed.md    # adaptive
└── bench/
    ├── README.md                   # how to run
    ├── .gitignore                  # __pycache__/, swe_slice_default.txt
    ├── run_ac_self_audit.py        # Tier 1 runner
    ├── run_bug_injection.py        # Tier 3 runner
    ├── run_swe_slice.sh            # Tier 2 runner
    └── vibe_check.py               # eyeball + auto-judge
```

### Why no production wiring yet

Touching `INDEX_RULES.md` Trigger Rule 10 or `workflows/qa-correctness.md` would itself be a markdown-only PR — exactly the regime the paper says we cannot reliably review with our current setup. Doing the experiment first, then touching production after the data, is the right ordering.
