### PR TITLE
OpenClaw on SNAP/mercury2 + Telegram — deployment runbook

### DIFF
--- a/experiments/01_self_hosted_openclaw/TODO.md
+++ b/experiments/01_self_hosted_openclaw/TODO.md
@@ -35,10 +35,12 @@
 
 ## Phase 4 — replicate to mercury2 (Linux, different recipe)
 
+Detailed runbook: [`snap_telegram_setup_plan.md`](./snap_telegram_setup_plan.md).
+
 - [ ] **4.1** Brando: confirm `ssh mercury2` works (per `MASTER_PLAN.md` Phase 4.1, last attempt failed with host-key verification). ⏱ 5 min
-- [ ] **4.2** Linux install path: `/dfs/scratch0/<user>/openclaw` + `~/openclaw` symlink, tmux + watchdog + `@reboot` cron + `krenew`. Need to write `install_openclaw_instance_linux.sh`. ⏱ 30 min
+- [x] **4.2** Linux install path: `/dfs/scratch0/<user>/openclaw` + `~/openclaw` symlink, tmux + watchdog + `@reboot` cron + `krenew`. ✅ `install_openclaw_instance_linux.sh` written (2026-05-09, PR #48).
 - [ ] **4.3** Brando: create third bot for mercury2; scp gogcli (different OS path: `~/.config/gogcli/`); `codex login` once. ⏱ 15 min
-- [ ] **4.4** SNAP-specific hardening: `krenew` cron, `@reboot` cron, logrotate. ⏱ 30 min
+- [x] **4.4** SNAP-specific hardening: `krenew` cron (already in `machine/snap.md:108-113`), `@reboot` cron (`start_openclaw_at_reboot.sh`), watchdog cron (`openclaw-watchdog.sh`), logrotate (`config/snap-logrotate.conf`). ✅ All artifacts in PR #48; activation happens when 4.2's installer runs on mercury2.
 
 ## Phase 5 — 7-day soak (Definition of Done)
 

--- a/experiments/01_self_hosted_openclaw/config/snap-logrotate.conf
+++ b/experiments/01_self_hosted_openclaw/config/snap-logrotate.conf
@@ -1,0 +1,8 @@
+/dfs/scratch0/brando9/.openclaw/logs/*.log {
+    daily
+    rotate 14
+    compress
+    missingok
+    notifempty
+    copytruncate
+}

--- a/experiments/01_self_hosted_openclaw/scripts/install_openclaw_instance_linux.sh
+++ b/experiments/01_self_hosted_openclaw/scripts/install_openclaw_instance_linux.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+# Install OpenClaw on a SNAP Linux GPU node (mercury2, skampere1, …).
+#
+# Sibling of install_openclaw_instance.sh (macOS). Different daemon path:
+# no launchd — uses tmux + @reboot cron + watchdog cron instead (per
+# machine/snap.md:104-120 watcher pattern).
+#
+# Idempotent: run as many times as you want. Skips work that's already done.
+# Driven by experiments/01_self_hosted_openclaw/snap_telegram_setup_plan.md.
+#
+# Usage (from the SNAP node itself):
+#   bash ~/agents-config/experiments/01_self_hosted_openclaw/scripts/install_openclaw_instance_linux.sh
+#
+# Prerequisites the script does NOT do for you (Step 2 of the runbook):
+#   - DFS scratch mounted at /dfs/scratch0/<user>
+#   - ~/agents-config checked out on DFS (per machine/snap.md New Node Setup)
+#   - Kerberos keytab + 4h krenew cron already installed
+#   - Node 22.14+ via NVM (sourced from ~/.bashrc)
+#   - codex CLI logged in (`codex login` once)
+#   - ~/keys/openclaw_telegram_bot_token.txt (mode 600) — token from @BotFather
+#
+# What it DOES (idempotent):
+#   - Symlinks ~/.openclaw → /dfs/scratch0/<user>/.openclaw (DFS-backed state)
+#   - npm install -g openclaw@latest under NVM prefix
+#   - Renders ~/.openclaw/openclaw.json from the shared template
+#   - Generates a fresh per-host gateway.auth.token (preserved on re-runs)
+#   - Installs @reboot + watchdog cron entries (preserves any existing krenew line)
+#   - Launches tmux session `openclaw-gateway` immediately (no reboot needed)
+#   - Smoke test: `openclaw infer model run --gateway --prompt 'PONG'`
+
+set -euo pipefail
+
+REPO_ROOT="${HOME}/agents-config"
+EXP_DIR="${REPO_ROOT}/experiments/01_self_hosted_openclaw"
+TEMPLATE="${EXP_DIR}/config/openclaw.json.template"
+OPENCLAW_DIR="${HOME}/.openclaw"
+TELEGRAM_TOKEN_FILE="${HOME}/keys/openclaw_telegram_bot_token.txt"
+DFS_USER_ROOT="/dfs/scratch0/$(id -un)"
+DFS_OPENCLAW_STATE="${DFS_USER_ROOT}/.openclaw"
+REBOOT_SCRIPT="${EXP_DIR}/scripts/start_openclaw_at_reboot.sh"
+WATCHDOG_SCRIPT="${EXP_DIR}/scripts/openclaw-watchdog.sh"
+LOGROTATE_CONF="${EXP_DIR}/config/snap-logrotate.conf"
+
+log() { printf '[install-linux] %s\n' "$*"; }
+die() { printf '[install-linux] ERROR: %s\n' "$*" >&2; exit 1; }
+
+[[ "$(uname -s)" == "Linux" ]] || die "this script is Linux-only — use install_openclaw_instance.sh on macOS"
+
+# --- prereq checks ---
+[[ -f "$TEMPLATE" ]] || die "config template not found at $TEMPLATE — did you 'git -C ~/agents-config pull'?"
+[[ -d "$DFS_USER_ROOT" ]] || die "DFS not mounted at $DFS_USER_ROOT — 'cd /dfs/scratch0' to trigger AutoFS, then retry"
+command -v node >/dev/null  || die "node not in PATH — source ~/.bashrc first (NVM loads node)"
+command -v npm  >/dev/null  || die "npm not in PATH"
+command -v codex >/dev/null || die "codex CLI missing — install it and run 'codex login' first"
+command -v tmux >/dev/null  || die "tmux not in PATH"
+[[ -f "$TELEGRAM_TOKEN_FILE" ]] || die "missing $TELEGRAM_TOKEN_FILE — create it from @BotFather token (mode 600)"
+[[ "$(stat -c '%a' "$TELEGRAM_TOKEN_FILE")" == "600" ]] \
+  || die "$TELEGRAM_TOKEN_FILE permissions must be 600 (currently $(stat -c '%a' "$TELEGRAM_TOKEN_FILE"))"
+[[ -x "$REBOOT_SCRIPT"   ]] || die "missing executable $REBOOT_SCRIPT"
+[[ -x "$WATCHDOG_SCRIPT" ]] || die "missing executable $WATCHDOG_SCRIPT"
+
+# --- Slurm guard: warn loudly if this node is gated ---
+# Heuristic: if the user can ssh in but pam_slurm_adopt is active, the @reboot
+# cron will silently fail post-reboot. Better to surface it now.
+if [[ -f /etc/pam.d/sshd ]] && grep -q 'pam_slurm_adopt' /etc/pam.d/sshd 2>/dev/null; then
+  log "⚠ pam_slurm_adopt detected on $(hostname). Reboot survival via @reboot cron may not work."
+  log "  See machine/snap.md:81-103 for the Slurm-migration table and sbatch-wrapper plan."
+fi
+
+# --- DFS-backed state dir (symlink ~/.openclaw → DFS) ---
+mkdir -p "${DFS_OPENCLAW_STATE}/logs"
+if [[ -L "$OPENCLAW_DIR" ]]; then
+  TARGET="$(readlink -f "$OPENCLAW_DIR" || true)"
+  [[ "$TARGET" == "$DFS_OPENCLAW_STATE" ]] || die "$OPENCLAW_DIR symlink points to $TARGET, not $DFS_OPENCLAW_STATE; refusing to overwrite"
+  log "~/.openclaw already symlinked to DFS"
+elif [[ -e "$OPENCLAW_DIR" ]]; then
+  die "$OPENCLAW_DIR exists as a real dir — move it to $DFS_OPENCLAW_STATE manually, then re-run"
+else
+  ln -sfn "$DFS_OPENCLAW_STATE" "$OPENCLAW_DIR"
+  log "symlinked ~/.openclaw → $DFS_OPENCLAW_STATE"
+fi
+
+# --- install OpenClaw if missing or out of date ---
+if ! command -v openclaw >/dev/null; then
+  log "installing openclaw via npm (global, under NVM prefix)"
+  npm install -g openclaw@latest
+else
+  log "openclaw already installed: $(openclaw --version 2>&1 | head -1)"
+fi
+
+# --- bootstrap ~/.openclaw via onboard (idempotent if already done) ---
+if [[ ! -f "${OPENCLAW_DIR}/openclaw.json" ]]; then
+  log "running 'openclaw onboard --non-interactive --accept-risk' to bootstrap config dir"
+  openclaw onboard --non-interactive --accept-risk || true
+fi
+
+# --- render config from template (preserve existing per-host token if present) ---
+log "rendering ${OPENCLAW_DIR}/openclaw.json from template"
+python3 - <<'PYEOF'
+import json, os, secrets
+from pathlib import Path
+
+template_path = Path(os.environ['HOME']) / "agents-config/experiments/01_self_hosted_openclaw/config/openclaw.json.template"
+out_path      = Path(os.environ['HOME']) / ".openclaw/openclaw.json"
+token_path    = Path(os.environ['HOME']) / "keys/openclaw_telegram_bot_token.txt"
+
+cfg = json.loads(template_path.read_text())
+
+# Preserve existing per-host gateway token if already set; otherwise generate fresh.
+existing = {}
+if out_path.exists():
+    try:
+        existing = json.loads(out_path.read_text())
+    except Exception:
+        pass
+
+existing_token = (
+    existing.get("gateway", {}).get("auth", {}).get("token")
+    or secrets.token_hex(32)
+)
+cfg.setdefault("gateway", {}).setdefault("auth", {})["mode"] = "token"
+cfg["gateway"]["auth"]["token"] = existing_token
+
+bot_token = token_path.read_text().strip()
+cfg.setdefault("channels", {}).setdefault("telegram", {})
+cfg["channels"]["telegram"]["enabled"] = True
+cfg["channels"]["telegram"]["botToken"] = bot_token
+cfg["channels"]["telegram"].pop("_comment", None)
+
+out_path.parent.mkdir(parents=True, exist_ok=True)
+out_path.write_text(json.dumps(cfg, indent=2) + "\n")
+out_path.chmod(0o600)
+print(f"wrote {out_path} (mode 600, gateway token {'preserved' if existing.get('gateway') else 'generated'})")
+PYEOF
+
+# --- launch / relaunch tmux session immediately (no reboot needed for first run) ---
+log "(re)launching tmux session 'openclaw-gateway'"
+tmux kill-session -t openclaw-gateway 2>/dev/null || true
+sleep 1
+tmux new-session -d -s openclaw-gateway \
+  "bash -lc 'openclaw gateway run 2>&1 | tee -a ~/.openclaw/logs/gateway-\$(date +%F).log'"
+sleep 6
+
+# --- install / refresh crontab entries (preserve krenew + anything unrelated) ---
+log "installing @reboot + watchdog crontab entries (preserves krenew + foreign lines)"
+TMP_CRON="$(mktemp)"
+trap 'rm -f "$TMP_CRON"' EXIT
+(crontab -l 2>/dev/null || true) \
+  | grep -vE "start_openclaw_at_reboot|openclaw-watchdog|openclaw/logs/.logrotate" \
+  > "$TMP_CRON"
+{
+  printf '@reboot %s\n'                  "$REBOOT_SCRIPT"
+  printf '*/2 * * * * %s\n'              "$WATCHDOG_SCRIPT"
+  printf '5 4 * * * /usr/sbin/logrotate -s %s/.openclaw/logs/.logrotate.state %s\n' \
+         "$DFS_USER_ROOT" "$LOGROTATE_CONF"
+} >> "$TMP_CRON"
+crontab "$TMP_CRON"
+log "crontab now contains:"
+crontab -l | grep -E "krenew|openclaw|logrotate" | sed 's/^/  /'
+
+# --- smoke test ---
+log "smoke test: openclaw infer model run --gateway --prompt 'PONG'"
+if openclaw infer model run --gateway --prompt "say only the word PONG" 2>&1 | grep -q "PONG"; then
+  log "✓ smoke test passed"
+else
+  die "smoke test failed — see 'openclaw doctor' and 'openclaw logs', and tmux attach -t openclaw-gateway"
+fi
+
+# --- finish + manual steps reminder ---
+cat <<EOF
+
+================================================================================
+[install-linux] OpenClaw is up on $(hostname).
+
+What's done:
+  - openclaw $(openclaw --version 2>&1 | head -1)
+  - tmux session 'openclaw-gateway' running (attach: tmux attach -t openclaw-gateway)
+  - State on DFS: $DFS_OPENCLAW_STATE
+  - @reboot + watchdog + logrotate cron entries installed
+  - Smoke test passed
+
+What you still need to do MANUALLY on this host (Steps 4.6, 4.7 of the runbook):
+  1. Pair the bot in Telegram (DM @ultimate_brando9_sk_<host>_bot, then if prompted):
+       openclaw pairing approve telegram <CODE>
+  2. Register the heartbeat cron:
+       openclaw cron add \\
+         --id heartbeat-$(hostname -s) \\
+         --cron "*/15 * * * *" \\
+         --action send-channel \\
+         --channel telegram --target openclaw-ops \\
+         --message "[$(hostname -s)-openclaw] alive @ \\\$(date -u +%FT%TZ)"
+  3. Copy gogcli auth from instance #1 (if not already done):
+       scp <air>:~/Library/Application\\ Support/gogcli/credentials.json \\
+           ~/.config/gogcli/credentials.json
+       chmod 600 ~/.config/gogcli/credentials.json
+       gog gmail list --max-results 1
+
+Verify end-to-end:
+  - tmux attach -t openclaw-gateway     # gateway logs
+  - openclaw channels status            # telegram should be green
+  - Within 15 min, openclaw-ops channel should show: [<host>-openclaw] alive @ ...
+================================================================================
+EOF

--- a/experiments/01_self_hosted_openclaw/scripts/openclaw-watchdog.sh
+++ b/experiments/01_self_hosted_openclaw/scripts/openclaw-watchdog.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Respawn the openclaw gateway tmux session if it has died.
+#
+# Wired into crontab as:  */2 * * * * /dfs/scratch0/<user>/agents-config/experiments/01_self_hosted_openclaw/scripts/openclaw-watchdog.sh
+# Equivalent of openclaw-health-watcher.sh (macOS) but Linux/tmux-flavored.
+#
+# Cheap: 99% of invocations are a single tmux has-session check that exits 0.
+set -euo pipefail
+
+LOG_DIR="${HOME}/.openclaw/logs"
+mkdir -p "$LOG_DIR"
+LOG="${LOG_DIR}/watchdog-$(date +%F).log"
+
+if tmux has-session -t openclaw-gateway 2>/dev/null; then
+  exit 0
+fi
+
+# Session is gone — restart it.
+{
+  echo "=== $(date -Is) openclaw-gateway session missing; respawning ==="
+  # shellcheck disable=SC1090
+  source "${HOME}/.bashrc" 2>/dev/null || true
+  tmux new-session -d -s openclaw-gateway \
+    "bash -lc 'openclaw gateway run 2>&1 | tee -a ${LOG_DIR}/gateway-\$(date +%F).log'"
+  sleep 5
+  if tmux has-session -t openclaw-gateway 2>/dev/null; then
+    echo "=== respawn OK ==="
+  else
+    echo "=== respawn FAILED ==="
+    exit 1
+  fi
+} >>"$LOG" 2>&1

--- a/experiments/01_self_hosted_openclaw/scripts/start_openclaw_at_reboot.sh
+++ b/experiments/01_self_hosted_openclaw/scripts/start_openclaw_at_reboot.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Re-launch the openclaw gateway in tmux after a SNAP node reboot.
+#
+# Wired into crontab as:  @reboot /dfs/scratch0/<user>/agents-config/experiments/01_self_hosted_openclaw/scripts/start_openclaw_at_reboot.sh
+# Mirrors the watcher pattern in machine/snap.md:108-120.
+#
+# Logs to /tmp/start_openclaw_at_reboot_<host>.log so post-mortem of a failed
+# boot is recoverable even before DFS comes up.
+set -euo pipefail
+
+LOG="/tmp/start_openclaw_at_reboot_$(hostname -s).log"
+exec >>"$LOG" 2>&1
+echo "=== $(date -Is) start_openclaw_at_reboot ==="
+
+DFS_USER_ROOT="/dfs/scratch0/$(id -un)"
+
+# 1. Wait for DFS to come up (up to ~5 min).
+for i in $(seq 1 60); do
+  [[ -d "$DFS_USER_ROOT" ]] && break
+  sleep 5
+done
+[[ -d "$DFS_USER_ROOT" ]] || { echo "DFS never came up; aborting"; exit 1; }
+
+# 2. Refresh Kerberos before touching anything AFS/DFS-protected.
+if [[ -x "${DFS_USER_ROOT}/bin/krenew.sh" ]]; then
+  "${DFS_USER_ROOT}/bin/krenew.sh" || echo "krenew.sh exited non-zero (continuing)"
+fi
+
+# 3. Source .bashrc to pick up NVM (node is needed by openclaw) + LFS HOME override.
+# shellcheck disable=SC1090
+source "${HOME}/.bashrc" 2>/dev/null || true
+
+# 4. (Re)launch gateway in tmux — idempotent.
+tmux kill-session -t openclaw-gateway 2>/dev/null || true
+sleep 1
+tmux new-session -d -s openclaw-gateway \
+  "bash -lc 'openclaw gateway run 2>&1 | tee -a ~/.openclaw/logs/gateway-\$(date +%F).log'"
+
+# 5. Sanity check.
+sleep 8
+if tmux has-session -t openclaw-gateway 2>/dev/null; then
+  echo "=== launched: tmux session openclaw-gateway live ==="
+else
+  echo "=== FAILED to start tmux session openclaw-gateway ==="
+  exit 1
+fi

--- a/experiments/01_self_hosted_openclaw/snap_telegram_setup_plan.md
+++ b/experiments/01_self_hosted_openclaw/snap_telegram_setup_plan.md
@@ -1,0 +1,334 @@
+# OpenClaw on SNAP — Telegram-Bridged Self-Hosted Agent on a GPU Node
+
+**TLDR:** Step-by-step deployment plan for installing OpenClaw on a SNAP GPU node (default: `mercury2`) so Brando can DM a Telegram bot from his phone and have an agent run on the lab GPU box. Expands [`MASTER_PLAN.md`](./MASTER_PLAN.md) **Phase 4** (4-step stub) into a concrete, executable runbook covering host selection, DFS-backed install layout, the missing Linux installer, Telegram bot creation, Kerberos + reboot survival, smoke tests, and rollback. Sister doc to [`scripts/install_openclaw_instance.sh`](./scripts/install_openclaw_instance.sh) (macOS) — the missing Linux counterpart is **deliverable #1** of this plan.
+
+> **Why this lives here.** This is OpenClaw instance #3 (after Air + Pro). Same architecture, same `bots.yaml` + `openclaw-ops` channel ([`chatops.md`](./chatops.md)), same idempotency story. The reason it needs its own doc is that SNAP is **Linux + DFS + no launchd + Slurm-migration-volatile**, so the macOS install script doesn't transfer.
+
+---
+
+## 1. Decisions to confirm before starting
+
+| # | Decision | Default (this plan assumes) | Alternatives |
+|---|---|---|---|
+| D1 | **Target node** | `mercury2` (per Phase 4) | `skampere1` (8× A100, also non-Slurm-gated). Avoid: `hyperturing2`, `turing3`, `ampere1–9`, `blackwell1` (Slurm-gated → daemon needs `sbatch` wrapper). |
+| D2 | **GPU usage by OpenClaw itself** | None — agent runs CPU-only; the node's GPUs stay free for training jobs | If we later want a local LLM as fallback, reserve 1× GPU and pin via `CUDA_VISIBLE_DEVICES`. Out of scope for v1. |
+| D3 | **Install script shape** | Sibling `install_openclaw_instance_linux.sh` (per [`MASTER_PLAN.md`](./MASTER_PLAN.md) §9 open decision #2) | Add a `case "$(uname -s)"` branch to the existing macOS script. Default is sibling — keeps each script readable and matches what `MASTER_PLAN.md` Phase 4.2 already proposes. |
+| D4 | **State dir location** | `~/.openclaw → /dfs/scratch0/brando9/.openclaw` (DFS-backed symlink, mirrors `~/.claude` per `machine/snap.md:228`) | Keep `~/.openclaw` on LFS (node-local, faster but lost on node migration). DFS-backed wins because: (a) survives node reboot/reimage, (b) makes future node-swap a 1-line change, (c) consistent with `agents-config` and `~/.claude`. |
+| D5 | **Daemon mechanism** | tmux session `openclaw-gateway` + watchdog while-loop + `@reboot` cron (per `machine/snap.md:108-113`) | systemd-user unit. Rejected: SNAP nodes don't reliably honor user-systemd; the existing watcher infra already uses tmux + cron and works. |
+| D6 | **Heartbeat ID** | `mercury2-openclaw` (matches `chatops.md` schema) | — |
+| D7 | **Bot per host** | Yes — third `@BotFather` bot `@ultimate_brando9_sk_mercury2_bot` (per [`concepts.md`](./concepts.md) Q1: shared token = 409 conflicts) | — |
+
+**👤 Brando: confirm D1, D2, D3 before Step 4.2 fires.** Defaults are safe but worth a 30-second sanity check.
+
+---
+
+## 2. Prerequisites — what must be true before step 1
+
+A row fails ⇒ STOP and fix that row first.
+
+| Check | Command | Pass criterion |
+|---|---|---|
+| SSH to target node works | `ssh mercury2.stanford.edu hostname` | Prints `mercury2`, no host-key prompt |
+| DFS scratch is mounted | `ssh mercury2 'ls /dfs/scratch0/brando9 \| head -3'` | Lists files (no `Stale file handle`) |
+| `agents-config` checked out on DFS | `ssh mercury2 'ls /dfs/scratch0/brando9/agents-config/CLAUDE.md'` | Exists |
+| Kerberos auto-renewal active | `ssh mercury2 'crontab -l \| grep krenew'` | One `0 */4 * * * .../krenew.sh` line present (per `machine/snap.md:108-113`) |
+| Keytab present on DFS | `ssh mercury2 'stat -c %a /dfs/scratch0/brando9/.keytab'` | `600` |
+| Node 22.14+ available | `ssh mercury2 'source ~/.bashrc && node --version'` | `v22.14.x` or `v24.x` (via NVM, per `machine/snap.md:160`) |
+| `codex` CLI logged in | `ssh mercury2 'source ~/.bashrc && codex whoami'` | Returns Brando's account, not `not logged in` |
+| Telegram bot token file | `ssh mercury2 'stat -c %a ~/keys/openclaw_telegram_bot_token.txt'` | `600` (created in Step 4.1 — initially absent, will be added) |
+
+⚠ **If `mercury2` ever migrates behind `pam_slurm_adopt`** (per `machine/snap.md:81-103` table), this plan needs a `sbatch --time=∞` wrapper. As of 2026-04-24 mercury2 is open. Re-check before you start.
+
+---
+
+## 3. End-state architecture (one picture)
+
+```
+┌──────────────────────── Brando's phone ────────────────────────┐
+│  Telegram  →  @ultimate_brando9_sk_mercury2_bot  (per-host)    │
+└────────────────────────────────┬───────────────────────────────┘
+                                 │  long-poll (one process per token)
+                                 ▼
+┌──────────────────────── mercury2.stanford.edu ─────────────────┐
+│                                                                │
+│  tmux session: openclaw-gateway                                │
+│    └─ openclaw gateway  (port 18789, loopback only)            │
+│       └─ codex harness (gpt-5.5, model_reasoning_effort=xhigh) │
+│                                                                │
+│  cron:                                                         │
+│    0 */4 * * *  krenew.sh                # K5 ticket refresh   │
+│    @reboot      start_openclaw_at_reboot.sh                    │
+│    */15 * * * * openclaw cron run heartbeat-mercury2           │
+│                                                                │
+│  paths:                                                        │
+│    ~/.openclaw → /dfs/scratch0/brando9/.openclaw  (state, DFS) │
+│    ~/openclaw  → /dfs/scratch0/brando9/openclaw   (code, DFS)  │
+│    ~/keys/openclaw_telegram_bot_token.txt         (LFS, 600)   │
+│                                                                │
+└─────────────┬──────────────────────────────────┬───────────────┘
+              │                                  │
+              ▼                                  ▼
+        ┌──────────────┐                ┌──────────────────┐
+        │ Gmail (gog)  │                │  openclaw-ops    │
+        │  brando9@cs  │                │  (TG channel,    │
+        └──────────────┘                │   shared by all  │
+                                        │   3 instances)   │
+                                        └──────────────────┘
+```
+
+**Why the gateway binds loopback-only:** SNAP nodes are reachable from anywhere on the Stanford network. Binding to `0.0.0.0` would expose the gateway's auth token surface to every other CS user. Loopback + `auth.mode=token` keeps it locked down; the only entry path is Telegram.
+
+---
+
+## 4. Steps
+
+Each step has an owner (👤 = Brando, 🤖 = Claude), an ETA, and a "done when" condition. Ordering matters — don't skip ahead.
+
+### Step 4.1 — 👤 Brando: create the mercury2 Telegram bot ⏱ 5 min
+
+1. Open Telegram → `@BotFather` → `/newbot`.
+2. Name: `Brando OpenClaw mercury2`. Username: `ultimate_brando9_sk_mercury2_bot`.
+3. Copy the token. On any machine with SSH to mercury2:
+   ```bash
+   ssh mercury2 'mkdir -p ~/keys && umask 077 && cat > ~/keys/openclaw_telegram_bot_token.txt' <<< 'PASTE_TOKEN_HERE'
+   ssh mercury2 'chmod 600 ~/keys/openclaw_telegram_bot_token.txt && wc -c ~/keys/openclaw_telegram_bot_token.txt'
+   ```
+   Expect ~46 bytes printed.
+4. In Telegram: open the existing private `openclaw-ops` channel → Manage Channel → Administrators → add `@ultimate_brando9_sk_mercury2_bot` with **Post Messages** permission only.
+5. DM the new bot once (`/start`). Don't expect a reply yet — gateway isn't running. The DM just unlocks the bot's ability to message you back later.
+
+**Done when:** `~/keys/openclaw_telegram_bot_token.txt` exists on mercury2 with mode 600.
+
+---
+
+### Step 4.2 — 🤖 Claude: write `install_openclaw_instance_linux.sh` ⏱ 30 min
+
+Sibling to the existing macOS installer, lives at `experiments/01_self_hosted_openclaw/scripts/install_openclaw_instance_linux.sh`. Differences from the macOS version:
+
+| Concern | macOS does | Linux must do |
+|---|---|---|
+| Daemon | `launchd` plist + `launchctl bootstrap` | tmux session `openclaw-gateway` running watchdog while-loop |
+| State dir | `~/.openclaw` (on internal SSD) | `~/.openclaw` symlinked to `/dfs/scratch0/brando9/.openclaw` (idempotent: `ln -sfn`) |
+| Code dir | npm global → Homebrew prefix | npm global → NVM prefix (per `machine/snap.md:160`); the install lands under `$NVM_DIR/versions/node/<v>/lib/node_modules/openclaw` |
+| Permission file | `chmod 600` on `openclaw.json` | same |
+| Cert fix | macOS-only `cafile=/etc/ssl/cert.pem` | skip (Linux uses system CA bundle by default) |
+| Reboot survival | `RunAtLoad` in plist | `@reboot` cron entry calling `start_openclaw_at_reboot.sh` |
+| Kerberos | n/a | rely on existing `0 */4 * * * krenew.sh` (already installed per `machine/snap.md:108-113`) |
+| stdin to gateway | child of launchd (no tty) | `tmux new-session -d -s openclaw-gateway` |
+| Slurm awareness | n/a | exit early with a clear error if the node is gated (`groups | grep -q slurm` heuristic) |
+
+The script reuses the existing `openclaw.json.template` rendering Python block from the macOS installer verbatim — only the daemon-installation tail differs.
+
+Companion script `start_openclaw_at_reboot.sh` (also new):
+```bash
+#!/usr/bin/env bash
+# Re-launch openclaw gateway in tmux after node reboot.
+# Logs to /tmp/start_openclaw_at_reboot_<host>.log so failures are recoverable.
+set -euo pipefail
+LOG="/tmp/start_openclaw_at_reboot_$(hostname -s).log"
+exec >>"$LOG" 2>&1
+echo "=== $(date -Is) start_openclaw_at_reboot ==="
+
+# 1. wait for DFS to come up (mirrors machine/snap.md pattern)
+for i in $(seq 1 60); do
+  [[ -d /dfs/scratch0/brando9 ]] && break
+  sleep 5
+done
+[[ -d /dfs/scratch0/brando9 ]] || { echo "DFS never came up; aborting"; exit 1; }
+
+# 2. refresh Kerberos before doing anything that touches AFS/DFS-protected paths
+/dfs/scratch0/brando9/bin/krenew.sh || true
+
+# 3. launch gateway in tmux (idempotent — kill old session first)
+source ~/.bashrc
+tmux kill-session -t openclaw-gateway 2>/dev/null || true
+tmux new-session -d -s openclaw-gateway "openclaw gateway run 2>&1 | tee -a ~/.openclaw/logs/gateway-$(date +%F).log"
+echo "=== launched ==="
+```
+
+**Done when:** the new script exists, is `chmod +x`, and a `bash -n` syntax check passes.
+
+---
+
+### Step 4.3 — 🤖 Claude: prepare DFS layout on mercury2 ⏱ 5 min
+
+```bash
+ssh mercury2 bash -lc '
+  set -euo pipefail
+  mkdir -p /dfs/scratch0/brando9/.openclaw/logs
+  ln -sfn /dfs/scratch0/brando9/.openclaw ~/.openclaw       # state on DFS
+  mkdir -p /dfs/scratch0/brando9/openclaw                   # code on DFS (npm prefix override below if needed)
+  ln -sfn /dfs/scratch0/brando9/openclaw ~/openclaw         # convenience symlink
+  ls -la ~/.openclaw ~/openclaw
+'
+```
+
+**Done when:** both symlinks resolve to `/dfs/scratch0/brando9/...`.
+
+---
+
+### Step 4.4 — 🤖 Claude: copy gogcli auth from Air ⏱ 5 min
+
+Per `MASTER_PLAN.md` Step 4.3 — different OS path:
+
+```bash
+# from the Air (instance #1):
+scp ~/.config/gogcli/credentials.json mercury2:.config/gogcli/credentials.json   # NB: macOS path is ~/Library/Application Support/gogcli/
+ssh mercury2 'chmod 600 ~/.config/gogcli/credentials.json && gog gmail list --max-results 1'
+```
+
+If the path differs on the Air's macOS install (typically `~/Library/Application Support/gogcli/`), adjust the source side. The destination path on Linux is always `~/.config/gogcli/` per XDG.
+
+**Done when:** `gog gmail list` on mercury2 returns ≥1 message.
+
+---
+
+### Step 4.5 — 🤖 Claude: run the Linux installer ⏱ 5 min
+
+```bash
+ssh mercury2 bash -lc '
+  cd ~/agents-config && git pull --ff-only
+  bash ~/agents-config/experiments/01_self_hosted_openclaw/scripts/install_openclaw_instance_linux.sh
+'
+```
+
+**What the script does (executable summary of Step 4.2's spec):**
+1. Pre-flight (node version, codex login, keytab, token file mode).
+2. `npm install -g openclaw@latest` under NVM.
+3. `openclaw onboard --non-interactive --accept-risk` to seed config dir.
+4. Render `~/.openclaw/openclaw.json` from `config/openclaw.json.template` (preserving any existing per-host gateway token).
+5. Install + register `start_openclaw_at_reboot.sh` in cron.
+6. Start tmux session immediately (so we don't have to reboot to validate).
+7. Smoke test: `openclaw infer model run --gateway --prompt "say only the word PONG"`.
+
+**Done when:** the script exits 0 and prints `✓ smoke test passed`.
+
+---
+
+### Step 4.6 — 🤖 Claude: register the heartbeat cron ⏱ 5 min
+
+```bash
+ssh mercury2 bash -lc '
+  openclaw cron add \
+    --id heartbeat-mercury2 \
+    --cron "*/15 * * * *" \
+    --action "send-channel" \
+    --channel telegram \
+    --target openclaw-ops \
+    --message "[mercury2-openclaw] alive @ \$(date -u +%FT%TZ)"
+  openclaw cron list | grep heartbeat-mercury2
+'
+```
+
+**Done when:** within 15 min, `openclaw-ops` channel shows `[mercury2-openclaw] alive @ ...`.
+
+---
+
+### Step 4.7 — 👤 Brando: pair the bot ⏱ 3 min
+
+DM `@ultimate_brando9_sk_mercury2_bot` and follow the prompt. If pairing requires a code:
+```bash
+ssh mercury2 'openclaw pairing approve telegram <CODE>'
+```
+
+Then send a test DM: `what host are you on?` → expect a reply that says `mercury2` and includes hostname/uptime.
+
+**Done when:** Brando gets a coherent reply from the bot DM.
+
+---
+
+### Step 4.8 — 🤖 Claude: SNAP-specific hardening ⏱ 20 min
+
+Per `MASTER_PLAN.md` Step 4.4 + lessons from `machine/snap.md`:
+
+1. **Verify krenew cron is present** (don't add if it already exists — `machine/snap.md:108-113` shows the canonical line):
+   ```bash
+   ssh mercury2 'crontab -l | grep -E "krenew|start_openclaw_at_reboot"'
+   ```
+   Expect both lines.
+
+2. **logrotate config** at `~/.openclaw/logs/logrotate.conf`:
+   ```
+   /dfs/scratch0/brando9/.openclaw/logs/*.log {
+       daily
+       rotate 14
+       compress
+       missingok
+       notifempty
+       copytruncate
+   }
+   ```
+   Add to user crontab: `5 4 * * * /usr/sbin/logrotate -s ~/.openclaw/logs/.logrotate.state ~/.openclaw/logs/logrotate.conf`.
+
+3. **tmux watchdog**: a 30-line bash script that loops `until tmux has-session -t openclaw-gateway; do tmux new-session -d -s openclaw-gateway 'openclaw gateway run'; sleep 30; done`. Wire it as `*/2 * * * *` so a crashed gateway respawns within 2 min. (Equivalent of `openclaw-health-watcher.sh` but Linux-flavored.)
+
+4. **Document Slurm-migration risk** in this file's §6 "Status & Log" — if mercury2 gets gated, the watchdog will fail silently after the next reboot since cron jobs can't `ssh` into a Slurm-only node.
+
+**Done when:** `crontab -l` on mercury2 shows krenew + reboot + logrotate + watchdog (4 lines), and a manual `tmux kill-session -t openclaw-gateway` triggers respawn within 2 min.
+
+---
+
+### Step 4.9 — 🤖 Claude + 👤 Brando: end-to-end proof ⏱ 10 min
+
+Three round-trips, all from Brando's phone:
+
+1. **Liveness:** DM the bot `status` → reply names mercury2 and lists current load.
+2. **Email round-trip:** DM `triage my admin emails` → bot picks the oldest unread admin email, drafts a reply, asks for `approve`. Brando says `approve` → bot sends → confirms `sent at <ts>`.
+3. **Channel visibility:** check `openclaw-ops` — heartbeat from mercury2 visible alongside Air + Pro.
+
+**Done when:** all three pass without manual intervention.
+
+---
+
+## 5. Test plan / DoD
+
+Lift directly from `MASTER_PLAN.md` Phase 5 but scoped to mercury2:
+
+- [ ] mercury2 heartbeats every 15 min for 7 consecutive days, no gaps >30 min
+- [ ] `tmux kill-session -t openclaw-gateway` triggers respawn within 2 min (verified once during week)
+- [ ] Node reboot (or simulated: `tmux kill-server`) recovers within 5 min via `@reboot` cron
+- [ ] No double-sends across Air/Pro/mercury2 (Gmail label idempotency catches it — same as Phase 2)
+- [ ] Brando triages ≥3 real admin emails *via the mercury2 bot specifically* (not just Air)
+
+If any item fails for >24h: roll back per §7.
+
+---
+
+## 6. Status & Log
+
+Append-only. New entries on top.
+
+| Date | Owner | Note |
+|---|---|---|
+| 2026-05-09 | Claude | Plan drafted in branch `claude/telegram-snap-setup-plan-0zMqQ`. Awaiting Brando approval of D1–D7 before Step 4.1 fires. |
+
+---
+
+## 7. Rollback
+
+If the experiment goes sideways (gateway in crashloop, eating CPU on mercury2, or Slurm migration breaks reboot survival):
+
+```bash
+ssh mercury2 bash -lc '
+  tmux kill-session -t openclaw-gateway 2>/dev/null || true
+  crontab -l | grep -vE "openclaw|start_openclaw_at_reboot" | crontab -
+  # State preserved at ~/.openclaw — uninstall is reversible by undoing the crontab edits.
+  npm uninstall -g openclaw   # optional; leaves room to redeploy later
+'
+```
+
+Notify the `openclaw-ops` channel manually: `[mercury2-openclaw] DECOMMISSIONED <date> <reason>`. Air + Pro continue covering Brando's triage load.
+
+---
+
+## 8. Cross-references
+
+- Master plan (Phase 4 stub this expands): [`MASTER_PLAN.md`](./MASTER_PLAN.md) §6 Phase 4
+- Why per-host bots: [`concepts.md`](./concepts.md) Q1
+- Why heartbeats + ops layer: [`concepts.md`](./concepts.md) Q2 + Q3
+- Fleet management once mercury2 lands: [`chatops.md`](./chatops.md) (`bots.yaml` registry adds a `mercury2-openclaw` entry)
+- SNAP filesystem + reboot + Kerberos playbook: [`../../machine/snap.md`](../../machine/snap.md)
+- Existing watcher pattern this borrows from: `machine/snap.md:104-120` (`launch_watcher_remote.sh` + `start_watcher_at_reboot.sh`)
+- Keytab one-time setup: [`../../init_no_passwords_snap_kinit.md`](../../init_no_passwords_snap_kinit.md)
+- macOS installer to mirror: [`scripts/install_openclaw_instance.sh`](./scripts/install_openclaw_instance.sh)
+- Phase 4 TODO checkboxes this drives: [`TODO.md`](./TODO.md) §"Phase 4 — replicate to mercury2"


### PR DESCRIPTION
**Closing without merge — superseded by work already on main.**

When this PR was drafted I was working from a view of main that pre-dated the OpenClaw SNAP work that has since landed:

- `1b2e77c` (May 9) — `OpenClaw: mercury2 (SNAP/Linux) install path + cross-platform watcher` — added `install_openclaw_instance_linux.sh` (288 lines, more thorough than the version in this PR), Linux-aware `openclaw-health-watcher.sh`, README "fast path" section.
- `073a848` (May 9) — Mega QA pass on the above (codex + CC review) with 7 fixes including `ensure_openclaw_workdir()` LFS→DFS migration, mode-600 enforcement helper, per-host bot sanity check.
- `b96ef28` (May 10) — Pro setup + `tools.profile=messaging` fix + `nativeHookRelay` patch.

Trying to merge this PR triggered a `405 merge conflicts` from the GitHub API; the conflicting files are `install_openclaw_instance_linux.sh` and `TODO.md`. Force-merging would overwrite the production-validated installer with the older, less-thorough version in this branch — which is the opposite of useful.

**What's net-new in this PR vs main:**

| File | Verdict |
|---|---|
| `snap_telegram_setup_plan.md` (334-line runbook) | Possibly redundant with the existing `runbook.md` on main + README "fast path" section. Re-evaluate before salvaging. |
| `scripts/start_openclaw_at_reboot.sh` | Main's installer already bakes `@reboot` cron logic into `install_openclaw_instance_linux.sh`. Check whether main's inline version is equivalent before extracting. |
| `scripts/openclaw-watchdog.sh` | Main upgraded `openclaw-health-watcher.sh` to be Linux-aware (`tmux has-session` path) — likely already covers this. |
| `config/snap-logrotate.conf` | Net-new. Cleanly separable. Worth a 10-line follow-up PR if main's installer doesn't already register logrotate. |

**Recommendation:** close this PR (done), keep the branch around for one week so the logrotate config (and maybe the runbook) can be cherry-picked into a tiny follow-up PR rebased onto current main. Anything not salvaged by then is fine to drop.

Branch remains at `claude/telegram-snap-setup-plan-0zMqQ` — no commits lost.