### PR TITLE
experiments/03: youtube transcript → repo takeaways loop

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,6 +5,7 @@
 
 - **Just do it** — When Brando gives a direct instruction (send email, run command, etc.), execute it immediately. Do not ask for confirmation, offer alternatives, or create drafts when "send" was requested. Only pause for truly destructive/irreversible actions on shared systems.
 - **No unnecessary drafts** — If told to "send" an email, send it. Only create a draft if explicitly asked for a draft.
+- **When external fetches fail** — If a needed external resource (video transcript, paywalled page, gated API, IP-blocked service) is unreachable: (1) log every attempt and its failure mode in a `fetch_attempts.md` next to the work, (2) capture whatever lighter metadata *is* reachable (e.g. oEmbed for YouTube), (3) build the rest of the deliverable as a clearly-marked skeleton with a populate-script, (4) ask the user to supply the missing piece. **Never fabricate the missing content.** Canonical example: `experiments/03_youtube_transcript_takeaway_loop/`.
 
 ## Mandatory Response Protocol (inline — do not skip)
 

--- a/experiments/03_youtube_transcript_takeaway_loop/README.md
+++ b/experiments/03_youtube_transcript_takeaway_loop/README.md
@@ -1,0 +1,51 @@
+# Experiment 03 — YouTube Transcript → Repo Takeaways Loop
+
+**Status:** Partial (transcript unavailable from sandbox; meta-takeaways captured)
+**Started:** 2026-05-26
+**Branch:** `claude/video-transcript-experiment-FXZNd`
+**Source video:** https://youtu.be/u-2F63eD9tE
+**Video title:** *Research Colloquium 05/07/26 — Vishnu Ravi, MD.*
+**Channel:** Stanford Division of Computational Medicine
+
+## What this experiment is
+
+Brando asked Claude Code to: "go through the transcript, get the text, and make a new
+experiment folder with what I can learn from this — main takeaway specially to improve
+this repo."
+
+The narrow goal was: distill one Stanford colloquium talk into concrete improvements
+to `agents-config`. The broader goal — the one this folder is actually about — is to
+turn arbitrary external talks/videos/papers into a repeatable "fetch → distill →
+patch the repo" loop.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `README.md` | This file — context and how to finish the experiment. |
+| `video_metadata.json` | oEmbed metadata for the source video (the one piece we *could* fetch). |
+| `fetch_attempts.md` | Log of every transcript-fetch method tried and how it failed. Useful as a debugging artifact and as evidence for the meta-takeaway. |
+| `fetch_transcript.sh` | Reusable bash helper that takes a YouTube URL and writes `transcript.md`. Run from a non-cloud IP (cloud IPs are blocked by YouTube). |
+| `transcript.md` | Placeholder. Populated either by `fetch_transcript.sh` or by pasting the transcript manually. |
+| `takeaways.md` | The main deliverable: concrete `agents-config` improvements suggested by this experience. |
+
+## How to finish (when transcript is available)
+
+1. From a residential IP (not a cloud sandbox), run:
+   ```
+   bash experiments/03_youtube_transcript_takeaway_loop/fetch_transcript.sh \
+     https://youtu.be/u-2F63eD9tE
+   ```
+   Or paste the transcript text into `transcript.md` manually.
+2. Re-run Claude on this folder with the prompt: "read transcript.md and update
+   takeaways.md with concrete repo improvements tied to specific files/sections."
+3. Open a follow-up PR that implements the highest-value takeaway (do not bundle
+   all takeaways into one PR — each should be reviewable independently).
+
+## Why the transcript was not fetched here
+
+Every fetch path the sandbox has — `WebFetch`, `yt-dlp`, `youtube-transcript-api`,
+the YouTube `timedtext` API directly, and several third-party transcript proxies —
+returned 403, 429, captcha redirects, or `IpBlocked`. The sandbox IP is in a range
+YouTube blocks. See `fetch_attempts.md` for the full log. This is itself a relevant
+finding for an agent-config repo (see takeaway #1 in `takeaways.md`).

--- a/experiments/03_youtube_transcript_takeaway_loop/README.md
+++ b/experiments/03_youtube_transcript_takeaway_loop/README.md
@@ -1,6 +1,6 @@
 # Experiment 03 — YouTube Transcript → Repo Takeaways Loop
 
-**Status:** Partial (transcript unavailable from sandbox; meta-takeaways captured)
+**Status:** Section A patches landed; Section B awaits transcript paste.
 **Started:** 2026-05-26
 **Branch:** `claude/video-transcript-experiment-FXZNd`
 **Source video:** https://youtu.be/u-2F63eD9tE
@@ -33,14 +33,21 @@ patch the repo" loop.
 
 1. From a residential IP (not a cloud sandbox), run:
    ```
-   bash experiments/03_youtube_transcript_takeaway_loop/fetch_transcript.sh \
-     https://youtu.be/u-2F63eD9tE
+   bash experiments/03_youtube_transcript_takeaway_loop/fetch_transcript.sh
    ```
-   Or paste the transcript text into `transcript.md` manually.
-2. Re-run Claude on this folder with the prompt: "read transcript.md and update
-   takeaways.md with concrete repo improvements tied to specific files/sections."
-3. Open a follow-up PR that implements the highest-value takeaway (do not bundle
-   all takeaways into one PR — each should be reviewable independently).
+   (Defaults to this video; or pass a URL.) Or paste the transcript text into
+   `transcript.md` manually.
+2. Re-run Claude on this folder with the prompt: "read transcript.md and fill
+   Section B of takeaways.md with cited, file-specific items."
+3. Open a follow-up PR per actionable takeaway.
+
+## What Section A delivered in this PR
+
+- `experiments/experiment_template_talk_distill.md` — reusable template.
+- `scripts/fetch_youtube_transcript.sh` — promoted, oEmbed-first helper.
+- `CLAUDE.md` — new "When external fetches fail" behavioral rule referencing
+  this folder.
+- Local `fetch_transcript.sh` is now a thin wrapper around the shared helper.
 
 ## Why the transcript was not fetched here
 

--- a/experiments/03_youtube_transcript_takeaway_loop/fetch_attempts.md
+++ b/experiments/03_youtube_transcript_takeaway_loop/fetch_attempts.md
@@ -1,0 +1,37 @@
+# Transcript Fetch Attempts — Log
+
+Date: 2026-05-26
+Sandbox: cloud IP (YouTube/Google blocks this range)
+Target: https://youtu.be/u-2F63eD9tE
+
+| # | Method | Command / URL | Result |
+|---|--------|---------------|--------|
+| 1 | `WebFetch` on short URL | `https://youtu.be/u-2F63eD9tE` | 303 redirect to `youtube.com/watch?v=...` |
+| 2 | `WebFetch` on long URL | `https://www.youtube.com/watch?v=u-2F63eD9tE` | 302 to `google.com/sorry/index?...` (captcha) |
+| 3 | `yt-dlp` w/ `--write-auto-sub` | `yt-dlp --skip-download --write-auto-sub ...` | SSL verify failed, then 429 Too Many Requests |
+| 4 | `yt-dlp` w/ `--no-check-certificates` | same as #3 + `--no-check-certificates` | "Sign in to confirm you're not a bot" |
+| 5 | `youtube-transcript-api` (Python) | `YouTubeTranscriptApi().fetch('u-2F63eD9tE')` | `IpBlocked` exception — "IPs from cloud providers are blocked by YouTube" |
+| 6 | Direct timedtext API | `curl https://www.youtube.com/api/timedtext?lang=en&v=u-2F63eD9tE` | Google "Sorry..." block page |
+| 7 | Direct timedtext API (json3) | same as #6 + `&fmt=json3` | Google "Sorry..." block page |
+| 8 | `WebFetch` to `youtubetranscript.com` | `https://youtubetranscript.com/?v=...` | 403 Forbidden |
+| 9 | `curl` to `youtubetranscript.com` | with browser UA | XML response: "YouTube is currently blocking us from fetching subtitles" |
+| 10 | `WebFetch` to `tactiq.io` | `https://tactiq.io/tools/youtube-transcript?yt=...` | 403 Forbidden |
+| 11 | `WebFetch` to `notegpt.io` API | `https://notegpt.io/api/v1/youtube-transcript?...` | 404 Not Found |
+| 12 | `WebFetch` to `kome.ai` API | `https://kome.ai/api/transcript?video_id=...` | 405 Method Not Allowed |
+| 13 | `WebFetch` to youtube-transcript.io | `https://www.youtube-transcript.io/videos/u-2F63eD9tE` | 403 Forbidden |
+| 14 | `WebFetch` to youtubetotranscript.com | `https://youtubetotranscript.com/transcript?v=...` | 403 Forbidden |
+| 15 | `WebFetch` to Wayback Machine | `https://web.archive.org/web/2026*/...` | Claude Code blocks web.archive.org |
+| 16 | oEmbed metadata fetch (worked) | `https://www.youtube.com/oembed?url=...&format=json` | 200 OK — title/author only, no transcript |
+| 17 | noembed.com (worked) | `https://noembed.com/embed?url=...` | 200 OK — title/author only, no transcript |
+
+## Root cause
+
+YouTube blocks the sandbox IP. Every direct and proxy path eventually contacts
+YouTube and fails. Cached transcript services either gate behind a frontend
+captcha or are themselves blocked from YouTube.
+
+## Workarounds that *would* work
+
+- Run `fetch_transcript.sh` from a residential IP.
+- Paste the transcript manually into `transcript.md`.
+- Use a paid transcript API with rotating residential proxies (overkill for one video).

--- a/experiments/03_youtube_transcript_takeaway_loop/fetch_transcript.sh
+++ b/experiments/03_youtube_transcript_takeaway_loop/fetch_transcript.sh
@@ -1,43 +1,8 @@
 #!/usr/bin/env bash
-# Fetch a YouTube transcript and write it to transcript.md (next to this script).
-#
-# Usage:
-#   bash fetch_transcript.sh <youtube_url>
-#
-# Run from a residential IP — YouTube blocks cloud-provider IP ranges. If you
-# see "IpBlocked" or 429 errors, this script cannot help; paste the transcript
-# manually instead.
-#
-# Requires Python 3 with `youtube-transcript-api` installed:
-#   pip install youtube-transcript-api
+# Thin wrapper around the shared helper. Defaults to this video and this folder.
+# See scripts/fetch_youtube_transcript.sh for the implementation.
 set -euo pipefail
-
-URL="${1:-}"
-if [[ -z "$URL" ]]; then
-  echo "usage: $0 <youtube_url_or_video_id>" >&2
-  exit 2
-fi
-
-# Extract video id from common URL shapes; fall back to assuming arg is the id.
-VIDEO_ID="$(printf '%s' "$URL" \
-  | sed -E 's#.*[?&]v=([^&]+).*#\1#; s#.*youtu\.be/([^?]+).*#\1#; s#.*embed/([^?]+).*#\1#')"
-
-OUT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-OUT_FILE="$OUT_DIR/transcript.md"
-
-python3 - "$VIDEO_ID" "$URL" "$OUT_FILE" <<'PY'
-import sys, datetime
-from youtube_transcript_api import YouTubeTranscriptApi
-
-video_id, url, out_file = sys.argv[1], sys.argv[2], sys.argv[3]
-api = YouTubeTranscriptApi()
-segments = api.fetch(video_id)
-
-with open(out_file, "w") as f:
-    f.write(f"# Transcript — {url}\n\n")
-    f.write(f"_Fetched {datetime.date.today().isoformat()} via youtube-transcript-api._\n\n")
-    f.write("## Verbatim\n\n")
-    for seg in segments:
-        f.write(seg.text.strip() + "\n")
-print(f"wrote {out_file} ({len(segments)} segments)")
-PY
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$DIR/../.." && pwd)"
+URL="${1:-https://youtu.be/u-2F63eD9tE}"
+exec bash "$REPO_ROOT/scripts/fetch_youtube_transcript.sh" "$URL" "$DIR"

--- a/experiments/03_youtube_transcript_takeaway_loop/fetch_transcript.sh
+++ b/experiments/03_youtube_transcript_takeaway_loop/fetch_transcript.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Fetch a YouTube transcript and write it to transcript.md (next to this script).
+#
+# Usage:
+#   bash fetch_transcript.sh <youtube_url>
+#
+# Run from a residential IP — YouTube blocks cloud-provider IP ranges. If you
+# see "IpBlocked" or 429 errors, this script cannot help; paste the transcript
+# manually instead.
+#
+# Requires Python 3 with `youtube-transcript-api` installed:
+#   pip install youtube-transcript-api
+set -euo pipefail
+
+URL="${1:-}"
+if [[ -z "$URL" ]]; then
+  echo "usage: $0 <youtube_url_or_video_id>" >&2
+  exit 2
+fi
+
+# Extract video id from common URL shapes; fall back to assuming arg is the id.
+VIDEO_ID="$(printf '%s' "$URL" \
+  | sed -E 's#.*[?&]v=([^&]+).*#\1#; s#.*youtu\.be/([^?]+).*#\1#; s#.*embed/([^?]+).*#\1#')"
+
+OUT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+OUT_FILE="$OUT_DIR/transcript.md"
+
+python3 - "$VIDEO_ID" "$URL" "$OUT_FILE" <<'PY'
+import sys, datetime
+from youtube_transcript_api import YouTubeTranscriptApi
+
+video_id, url, out_file = sys.argv[1], sys.argv[2], sys.argv[3]
+api = YouTubeTranscriptApi()
+segments = api.fetch(video_id)
+
+with open(out_file, "w") as f:
+    f.write(f"# Transcript — {url}\n\n")
+    f.write(f"_Fetched {datetime.date.today().isoformat()} via youtube-transcript-api._\n\n")
+    f.write("## Verbatim\n\n")
+    for seg in segments:
+        f.write(seg.text.strip() + "\n")
+print(f"wrote {out_file} ({len(segments)} segments)")
+PY

--- a/experiments/03_youtube_transcript_takeaway_loop/takeaways.md
+++ b/experiments/03_youtube_transcript_takeaway_loop/takeaways.md
@@ -13,66 +13,64 @@ takeaways below are split into two clearly labelled sections:
 
 ## Section A — Meta-takeaways from the fetch attempt
 
-### A1. Add a "talk-distillation" experiment template
+### A1. Add a "talk-distillation" experiment template — **DONE**
 
-The repo has `experiments/experiment_template_readme.tex` aimed at ML-research
+The repo's `experiments/experiment_template_readme.tex` is aimed at ML-research
 experiments (Objective / Hypothesis / Dataset / Metric). It does not fit
-"distil a talk or paper into repo changes." Today every video/talk experiment
-will reinvent the layout.
+"distil a talk or paper into repo changes." Every video/talk experiment was
+about to reinvent the layout.
 
-**Concrete change:** add `experiments/experiment_template_talk_distill.md`
-with the structure used in this folder (README + metadata.json + fetch log +
-fetch script + transcript.md + takeaways.md), so the next talk-to-takeaways
-loop is `cp -r` away.
+**Done in this PR:** added `experiments/experiment_template_talk_distill.md`
+codifying the structure used here (README + metadata.json + fetch log +
+fetch script + transcript.md + takeaways.md), with a fixed item shape for
+takeaways and a definition-of-done.
 
-### A2. Promote `fetch_transcript.sh` to `scripts/`
+### A2. Promote `fetch_transcript.sh` to `scripts/` — **DONE**
 
-Right now `fetch_transcript.sh` lives inside this experiment. Every future
-experiment that wants to ingest a YouTube talk will copy-paste it.
+The fetch helper used to live only inside this experiment. Every future
+experiment that wants to ingest a YouTube talk would have copy-pasted it.
 
-**Concrete change:** move the script to `scripts/fetch_youtube_transcript.sh`
-once it is shown to work from a non-blocked machine, and reference it from the
-talk-distillation template. Keep the experiment-local copy as a thin wrapper
-that calls the shared one.
+**Done in this PR:** moved the implementation to
+`scripts/fetch_youtube_transcript.sh` (now always writes
+`video_metadata.json` first, then attempts the transcript; appends to
+`fetch_attempts.md` on failure). The experiment-local `fetch_transcript.sh`
+is now a 5-line wrapper.
 
-### A3. Codify the "external fetch is blocked" failure mode in `CLAUDE.md`
+### A3. Codify "external fetch is blocked" failure mode in `CLAUDE.md` — **DONE**
 
 When an agent cannot reach an external resource, the correct behaviour is
 (a) log the attempts, (b) capture whatever metadata *is* reachable (oEmbed
 worked here), (c) build the rest of the deliverable as a skeleton, and
-(d) ask the user for the missing piece — never fabricate. The current
-`CLAUDE.md` does not say this anywhere.
+(d) ask the user for the missing piece — never fabricate.
 
-**Concrete change:** append a "When external fetches fail" bullet to the
-Mandatory Response Protocol in `CLAUDE.md` (or in `INDEX_RULES.md` if it
-lives there), with the four-step pattern above. Reference this experiment as
-the canonical example.
+**Done in this PR:** added a "When external fetches fail" behavioral rule to
+`CLAUDE.md` with the four-step pattern, referencing this experiment as the
+canonical example.
 
-### A4. Cache oEmbed metadata before the transcript step
+### A4. Always-fetch oEmbed metadata first — **DONE**
 
 `https://www.youtube.com/oembed` and `https://noembed.com/embed` were the only
-two YouTube endpoints that *did* answer. They give title, channel, thumbnail
-— enough to start an experiment folder even when the transcript itself is
-out of reach. The template should fetch oEmbed *first* so the experiment
-folder is partially populated even on a total transcript failure.
+two YouTube endpoints that answered. They give title, channel, thumbnail —
+enough to start an experiment folder even when the transcript itself is out
+of reach.
 
-**Concrete change:** add an `oembed` step to the talk-distillation script
-that always runs and always writes `video_metadata.json`, independent of
-whether the transcript fetch succeeds.
+**Done in this PR:** `scripts/fetch_youtube_transcript.sh` always runs the
+oEmbed step first and writes `video_metadata.json` independently of whether
+the transcript fetch succeeds.
 
-### A5. Add `WebFetch` allow/deny notes for known-blocked hosts
+### A5. Allowlist oEmbed hosts via project settings — **DEFERRED**
 
-The repo's `.claude/settings.json` could pre-allow the oEmbed hosts (so the
-permission prompt is skipped on read-only metadata calls) and document which
-YouTube paths are known not to work from this sandbox so future Claude sessions
-don't burn time rediscovering it. The `fewer-permission-prompts` skill is the
-right place to add this.
+The repo could pre-allow the oEmbed hosts (so the permission prompt is
+skipped on read-only metadata calls) and document which YouTube paths are
+known not to work from this sandbox. The `fewer-permission-prompts` skill is
+the right driver.
 
-**Concrete change:** run `/fewer-permission-prompts` after this PR merges and
-add `WebFetch(https://www.youtube.com/oembed*)` and
-`WebFetch(https://noembed.com/*)` to the project allowlist; leave a comment
-that direct `youtube.com`, `googlevideo.com`, and `youtu.be` fetches are
-blocked from cloud IPs.
+**Status:** deferred to a follow-up because it requires a transcript-of-a-real-
+session to populate `.claude/settings.json` properly. To execute: run
+`/fewer-permission-prompts` and add `WebFetch(https://www.youtube.com/oembed*)`
+plus `WebFetch(https://noembed.com/*)` to the project allowlist, with a
+comment noting that direct `youtube.com`, `googlevideo.com`, and `youtu.be`
+fetches are blocked from cloud IPs.
 
 ---
 

--- a/experiments/03_youtube_transcript_takeaway_loop/takeaways.md
+++ b/experiments/03_youtube_transcript_takeaway_loop/takeaways.md
@@ -1,0 +1,105 @@
+# Takeaways — Improvements to `agents-config`
+
+**Scope note.** The original ask was "main takeaways from the talk to improve this
+repo." Since the transcript could not be fetched (see `fetch_attempts.md`), the
+takeaways below are split into two clearly labelled sections:
+
+- **Section A — Meta-takeaways from the *attempt*** (concrete; tied to files in
+  this repo; can be acted on today).
+- **Section B — Placeholders for content-takeaways** (to be filled once
+  `transcript.md` is populated).
+
+---
+
+## Section A — Meta-takeaways from the fetch attempt
+
+### A1. Add a "talk-distillation" experiment template
+
+The repo has `experiments/experiment_template_readme.tex` aimed at ML-research
+experiments (Objective / Hypothesis / Dataset / Metric). It does not fit
+"distil a talk or paper into repo changes." Today every video/talk experiment
+will reinvent the layout.
+
+**Concrete change:** add `experiments/experiment_template_talk_distill.md`
+with the structure used in this folder (README + metadata.json + fetch log +
+fetch script + transcript.md + takeaways.md), so the next talk-to-takeaways
+loop is `cp -r` away.
+
+### A2. Promote `fetch_transcript.sh` to `scripts/`
+
+Right now `fetch_transcript.sh` lives inside this experiment. Every future
+experiment that wants to ingest a YouTube talk will copy-paste it.
+
+**Concrete change:** move the script to `scripts/fetch_youtube_transcript.sh`
+once it is shown to work from a non-blocked machine, and reference it from the
+talk-distillation template. Keep the experiment-local copy as a thin wrapper
+that calls the shared one.
+
+### A3. Codify the "external fetch is blocked" failure mode in `CLAUDE.md`
+
+When an agent cannot reach an external resource, the correct behaviour is
+(a) log the attempts, (b) capture whatever metadata *is* reachable (oEmbed
+worked here), (c) build the rest of the deliverable as a skeleton, and
+(d) ask the user for the missing piece — never fabricate. The current
+`CLAUDE.md` does not say this anywhere.
+
+**Concrete change:** append a "When external fetches fail" bullet to the
+Mandatory Response Protocol in `CLAUDE.md` (or in `INDEX_RULES.md` if it
+lives there), with the four-step pattern above. Reference this experiment as
+the canonical example.
+
+### A4. Cache oEmbed metadata before the transcript step
+
+`https://www.youtube.com/oembed` and `https://noembed.com/embed` were the only
+two YouTube endpoints that *did* answer. They give title, channel, thumbnail
+— enough to start an experiment folder even when the transcript itself is
+out of reach. The template should fetch oEmbed *first* so the experiment
+folder is partially populated even on a total transcript failure.
+
+**Concrete change:** add an `oembed` step to the talk-distillation script
+that always runs and always writes `video_metadata.json`, independent of
+whether the transcript fetch succeeds.
+
+### A5. Add `WebFetch` allow/deny notes for known-blocked hosts
+
+The repo's `.claude/settings.json` could pre-allow the oEmbed hosts (so the
+permission prompt is skipped on read-only metadata calls) and document which
+YouTube paths are known not to work from this sandbox so future Claude sessions
+don't burn time rediscovering it. The `fewer-permission-prompts` skill is the
+right place to add this.
+
+**Concrete change:** run `/fewer-permission-prompts` after this PR merges and
+add `WebFetch(https://www.youtube.com/oembed*)` and
+`WebFetch(https://noembed.com/*)` to the project allowlist; leave a comment
+that direct `youtube.com`, `googlevideo.com`, and `youtu.be` fetches are
+blocked from cloud IPs.
+
+---
+
+## Section B — Content takeaways (TODO)
+
+To be filled once `transcript.md` is populated. Each item should follow this
+shape so it is actionable, not generic:
+
+> **Claim from talk (≤2 sentences, with timestamp):**
+> **What in the repo it touches (file:line or section):**
+> **Proposed change (concrete diff or new file):**
+> **Why it is worth doing (1 sentence):**
+
+Speaker context (from public profiles, not the talk itself — to be confirmed
+against the transcript): Vishnu Ravi works on Stanford Spezi (open-source
+modular framework for digital health apps), LLM-based EHR querying, and
+AI-driven care platforms. Plausible themes likely to appear in the talk and to
+have parallels in this repo:
+
+- **Modular, standards-based composition** (Spezi's design philosophy) →
+  parallels to how `~/agents-config` composes hooks, skills, and agents. Look
+  for advice on module boundaries, versioning, or capability declaration.
+- **LLM-on-EHR evaluation methodology** → parallels to the QA-gate experiment
+  (`experiments/00_refactor_qa_gate/`). Look for evaluation patterns,
+  hallucination-mitigation tactics, or human-in-the-loop checkpoints.
+- **Open-source health-tooling governance** → parallels to how this repo
+  manages its own self-improving config (`todo_self_improving_agents_config.md`).
+
+Re-read the transcript with the above hooks in mind and replace this section
+with specific, cited items.

--- a/experiments/03_youtube_transcript_takeaway_loop/transcript.md
+++ b/experiments/03_youtube_transcript_takeaway_loop/transcript.md
@@ -1,0 +1,20 @@
+# Transcript — https://youtu.be/u-2F63eD9tE
+
+_Status: **NOT YET FETCHED**. The sandbox IP is blocked by YouTube (see `fetch_attempts.md`)._
+
+## How to populate this file
+
+Pick one:
+
+1. **Run the fetch script from a non-cloud IP:**
+   ```
+   bash experiments/03_youtube_transcript_takeaway_loop/fetch_transcript.sh \
+     https://youtu.be/u-2F63eD9tE
+   ```
+2. **Paste manually:** Open the video, click *Show transcript* under the
+   description, copy the text, and replace everything below the
+   `## Verbatim` heading with it.
+
+## Verbatim
+
+_(transcript text goes here)_

--- a/experiments/03_youtube_transcript_takeaway_loop/video_metadata.json
+++ b/experiments/03_youtube_transcript_takeaway_loop/video_metadata.json
@@ -1,0 +1,17 @@
+{
+  "source_url": "https://youtu.be/u-2F63eD9tE",
+  "fetched_at": "2026-05-26",
+  "fetched_via": "https://www.youtube.com/oembed",
+  "title": "Research Colloquium 05/07/26 - Vishnu Ravi, MD.",
+  "author_name": "Stanford Division of Computational Medicine",
+  "author_url": "https://www.youtube.com/@stanfordcompmed",
+  "thumbnail_url": "https://i.ytimg.com/vi/u-2F63eD9tE/hqdefault.jpg",
+  "provider_name": "YouTube",
+  "speaker_public_profiles": {
+    "stanford_profile": "https://profiles.stanford.edu/vishnu-ravi",
+    "stanford_medicine": "https://med.stanford.edu/profiles/vishnu-ravi",
+    "biodesign": "https://bdh.stanford.edu/people/vishnu-ravi",
+    "spezi": "https://spezi.stanford.edu/people/vishnu-ravi",
+    "personal": "https://vishnu.io/"
+  }
+}

--- a/experiments/experiment_template_talk_distill.md
+++ b/experiments/experiment_template_talk_distill.md
@@ -1,0 +1,64 @@
+# Experiment NN — [Speaker / Talk Title] → Repo Takeaways
+
+**Status:** [Skeleton / Transcript Captured / Takeaways Drafted / Patches Merged]
+**Started:** YYYY-MM-DD
+**Branch:** `claude/<slug>`
+**Source:** [video / paper / podcast URL]
+**Title / Author:** [from oEmbed or manual]
+
+## Purpose
+
+This template is for the recurring loop: "take an external talk or paper,
+distil it, and turn the distillation into concrete patches to `agents-config`."
+It is *not* for ML-research experiments — for those, copy
+`experiment_template_readme.tex` instead.
+
+## Required files
+
+```
+experiments/NN_<slug>/
+├── README.md              <- this template, filled in
+├── video_metadata.json    <- written by scripts/fetch_youtube_transcript.sh (oEmbed)
+├── fetch_attempts.md      <- log of every fetch attempt + outcome; only created on failure
+├── transcript.md          <- verbatim transcript (auto-fetched or pasted)
+└── takeaways.md           <- Section A: meta-takeaways  /  Section B: content-takeaways
+```
+
+## Bootstrap commands
+
+```bash
+SLUG="NN_<slug>"
+mkdir -p "experiments/$SLUG"
+bash scripts/fetch_youtube_transcript.sh <youtube_url> "experiments/$SLUG"
+# transcript.md will be missing if YouTube blocks this IP — paste manually.
+```
+
+## `takeaways.md` item shape
+
+Every takeaway must be actionable, traceable, and small. Use this shape:
+
+> **Claim from source (≤2 sentences, with timestamp/page):**
+> **What in the repo it touches (file:line or section):**
+> **Proposed change (concrete diff or new file path):**
+> **Why it is worth doing (1 sentence):**
+
+Group takeaways into two sections:
+
+- **Section A — Meta-takeaways from the *attempt itself*** (process, tooling,
+  blockers). Often the most valuable when the source content is partly
+  unreachable.
+- **Section B — Content-takeaways from the source itself.** Cite the
+  transcript or paper. Do not paraphrase generically.
+
+## Definition of done
+
+- [ ] `transcript.md` is populated, OR the reason it cannot be is documented in `fetch_attempts.md`.
+- [ ] `takeaways.md` has at least one Section A item *and* one Section B item, each following the shape above.
+- [ ] Each high-value takeaway has its own follow-up PR (do not bundle).
+- [ ] PR opened as draft until takeaways are reviewable.
+
+## Reference
+
+- Canonical example: `experiments/03_youtube_transcript_takeaway_loop/`.
+- Fetch helper: `scripts/fetch_youtube_transcript.sh`.
+- Behavioural rule: "When external fetches fail" in `CLAUDE.md`.

--- a/scripts/fetch_youtube_transcript.sh
+++ b/scripts/fetch_youtube_transcript.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Fetch a YouTube video's oEmbed metadata and (when reachable) its transcript.
+#
+# Usage:
+#   bash scripts/fetch_youtube_transcript.sh <youtube_url_or_video_id> [out_dir]
+#
+# Writes into <out_dir> (default = current directory):
+#   - video_metadata.json   always written (oEmbed succeeds even when transcript fetch is blocked)
+#   - transcript.md         written only if youtube-transcript-api succeeds
+#   - fetch_attempts.md     appended on failure with the failure mode
+#
+# YouTube blocks cloud-provider IP ranges. If you see "IpBlocked", "429", or
+# captcha redirects, run this from a residential network or paste the
+# transcript manually into transcript.md (see experiments/03 README).
+#
+# Requires: bash, curl, python3, `pip install youtube-transcript-api`.
+set -euo pipefail
+
+URL_OR_ID="${1:-}"
+OUT_DIR="${2:-.}"
+if [[ -z "$URL_OR_ID" ]]; then
+  echo "usage: $0 <youtube_url_or_video_id> [out_dir]" >&2
+  exit 2
+fi
+mkdir -p "$OUT_DIR"
+
+VIDEO_ID="$(printf '%s' "$URL_OR_ID" \
+  | sed -E 's#.*[?&]v=([^&]+).*#\1#; s#.*youtu\.be/([^?]+).*#\1#; s#.*embed/([^?]+).*#\1#')"
+URL="https://youtu.be/${VIDEO_ID}"
+
+echo "[1/2] fetching oEmbed metadata for $URL ..."
+META_RAW="$(curl -sfL --max-time 15 \
+  "https://www.youtube.com/oembed?url=${URL}&format=json" \
+  || curl -sfL --max-time 15 "https://noembed.com/embed?url=${URL}" \
+  || true)"
+
+if [[ -z "$META_RAW" ]]; then
+  echo "  oEmbed failed (both endpoints). Writing stub." >&2
+  printf '{"source_url":"%s","fetched_at":"%s","error":"oembed_unreachable"}\n' \
+    "$URL" "$(date -I)" > "$OUT_DIR/video_metadata.json"
+else
+  python3 - "$URL" "$META_RAW" "$OUT_DIR/video_metadata.json" <<'PY'
+import json, sys, datetime
+url, raw, out = sys.argv[1], sys.argv[2], sys.argv[3]
+data = json.loads(raw)
+data["source_url"] = url
+data["fetched_at"] = datetime.date.today().isoformat()
+data["fetched_via"] = "oembed"
+with open(out, "w") as f:
+    json.dump(data, f, indent=2)
+PY
+  echo "  wrote $OUT_DIR/video_metadata.json"
+fi
+
+echo "[2/2] fetching transcript ..."
+if ! python3 -c "import youtube_transcript_api" 2>/dev/null; then
+  echo "  youtube-transcript-api not installed; skipping. Run: pip install youtube-transcript-api" >&2
+  exit 0
+fi
+
+set +e
+python3 - "$VIDEO_ID" "$URL" "$OUT_DIR/transcript.md" <<'PY' 2> "$OUT_DIR/.transcript_err"
+import sys, datetime
+from youtube_transcript_api import YouTubeTranscriptApi
+
+video_id, url, out_file = sys.argv[1], sys.argv[2], sys.argv[3]
+segments = YouTubeTranscriptApi().fetch(video_id)
+with open(out_file, "w") as f:
+    f.write(f"# Transcript — {url}\n\n")
+    f.write(f"_Fetched {datetime.date.today().isoformat()} via youtube-transcript-api._\n\n")
+    f.write("## Verbatim\n\n")
+    for seg in segments:
+        f.write(seg.text.strip() + "\n")
+print(f"wrote {out_file} ({len(segments)} segments)")
+PY
+RC=$?
+set -e
+
+if [[ $RC -ne 0 ]]; then
+  ERR="$(cat "$OUT_DIR/.transcript_err" 2>/dev/null | tail -3 | tr '\n' ' ')"
+  rm -f "$OUT_DIR/.transcript_err"
+  echo "  transcript fetch failed: $ERR" >&2
+  {
+    echo ""
+    echo "## $(date -I) — additional attempt"
+    echo "- \`scripts/fetch_youtube_transcript.sh $URL\` failed: \`${ERR}\`"
+  } >> "$OUT_DIR/fetch_attempts.md"
+  exit $RC
+fi
+
+rm -f "$OUT_DIR/.transcript_err"


### PR DESCRIPTION
## Summary

- New experiment folder `experiments/03_youtube_transcript_takeaway_loop/` aiming to distil a Stanford colloquium video (*Research Colloquium 05/07/26 — Vishnu Ravi, MD.*, https://youtu.be/u-2F63eD9tE) into concrete repo improvements.
- The transcript itself could **not** be fetched from the sandbox — YouTube blocks this IP across every method (yt-dlp, `youtube-transcript-api`, direct `timedtext` API, third-party transcript proxies). Every attempt is logged in `fetch_attempts.md`.
- `takeaways.md` therefore has two sections: **Section A** captures meta-takeaways from the *attempt itself* (talk-distillation template, promoting `fetch_transcript.sh` to `scripts/`, a `CLAUDE.md` rule for external-fetch failures, pre-fetching oEmbed metadata, an allowlist tweak for the oEmbed hosts). **Section B** is a TODO with a fixed item shape, to be filled once `transcript.md` is populated.

## How to finish

1. From a residential IP, run `bash experiments/03_youtube_transcript_takeaway_loop/fetch_transcript.sh https://youtu.be/u-2F63eD9tE` — or paste the transcript manually into `transcript.md`.
2. Re-run Claude on the folder with: "read transcript.md and update takeaways.md Section B with cited, file-specific changes." Open a follow-up PR per actionable takeaway.

## Test plan

- [ ] `fetch_transcript.sh` runs cleanly from a non-cloud machine and writes a non-empty `transcript.md`.
- [ ] Section A takeaways link to real files/sections in the repo (verified by hand).
- [ ] No secrets in the diff; meta-only.

https://claude.ai/code/session_013zqn8Xok6V4nBRoqHazGxc

---
_Generated by [Claude Code](https://claude.ai/code/session_013zqn8Xok6V4nBRoqHazGxc)_